### PR TITLE
Fix: Use native Google Calendar API attachments

### DIFF
--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -237,7 +237,7 @@ func displayEventsAsTable(events []*calendar.Event, start, end time.Time, calend
 		// Convert to model for rich data access with drive integration
 		var modelEvent *models.CalendarEvent
 		if driveService != nil {
-			modelEvent = calendarService.ConvertToModelWithDrive(event, driveService)
+			modelEvent = calendarService.ConvertToModelWithDrive(event)
 		} else {
 			modelEvent = calendarService.ConvertToModel(event)
 		}
@@ -283,11 +283,11 @@ func displayEventsAsTable(events []*calendar.Event, start, end time.Time, calend
 				fmt.Printf("  📝 %s\n", description)
 			}
 
-			// Show attached Google Docs
-			if len(modelEvent.AttachedDocs) > 0 {
-				fmt.Printf("  📄 Attached Docs:\n")
-				for _, doc := range modelEvent.AttachedDocs {
-					fmt.Printf("    - %s (%s)\n", doc.Name, doc.WebViewLink)
+			// Show attached files
+			if len(modelEvent.Attachments) > 0 {
+				fmt.Printf("  📄 Attachments:\n")
+				for _, attachment := range modelEvent.Attachments {
+					fmt.Printf("    - %s (%s)\n", attachment.Title, attachment.FileURL)
 				}
 			}
 		}
@@ -342,7 +342,7 @@ func displayEventsAsJSON(events []*calendar.Event, calendarService *internalcale
 	modelEvents := make([]*models.CalendarEvent, len(events))
 	for i, event := range events {
 		if driveService != nil {
-			modelEvents[i] = calendarService.ConvertToModelWithDrive(event, driveService)
+			modelEvents[i] = calendarService.ConvertToModelWithDrive(event)
 		} else {
 			modelEvents[i] = calendarService.ConvertToModel(event)
 		}

--- a/internal/sources/google/source.go
+++ b/internal/sources/google/source.go
@@ -58,7 +58,7 @@ func (g *GoogleSource) Fetch(since time.Time, limit int) ([]*models.Item, error)
 	var items []*models.Item
 	for _, event := range events {
 		// Convert to our model first
-		calEvent := g.calendarService.ConvertToModelWithDrive(event, g.driveService)
+		calEvent := g.calendarService.ConvertToModelWithDrive(event)
 		
 		// Then convert to universal Item format
 		item := models.FromCalendarEvent(calEvent)

--- a/pkg/models/event.go
+++ b/pkg/models/event.go
@@ -11,7 +11,15 @@ type CalendarEvent struct {
 	Location    string
 	Attendees   []string
 	MeetingURL  string
-	AttachedDocs []DriveFile
+	Attachments []CalendarAttachment
+}
+
+type CalendarAttachment struct {
+	FileURL  string
+	FileID   string
+	Title    string
+	MimeType string
+	IconLink string
 }
 
 type DriveFile struct {
@@ -23,3 +31,4 @@ type DriveFile struct {
 	Owners       []string
 	Shared       bool
 }
+

--- a/pkg/models/item.go
+++ b/pkg/models/item.go
@@ -49,13 +49,13 @@ func FromCalendarEvent(event *CalendarEvent) *Item {
 		},
 	}
 
-	// Convert Drive attachments
-	for _, doc := range event.AttachedDocs {
+	// Convert Calendar attachments
+	for _, attachment := range event.Attachments {
 		item.Attachments = append(item.Attachments, Attachment{
-			ID:       doc.ID,
-			Name:     doc.Name,
-			MimeType: doc.MimeType,
-			URL:      doc.WebViewLink,
+			ID:       attachment.FileID,
+			Name:     attachment.Title,
+			MimeType: attachment.MimeType,
+			URL:      attachment.FileURL,
 		})
 	}
 


### PR DESCRIPTION
## Summary
- Replace fragile description text parsing with proper Google Calendar API attachment handling
- Fix issue where documents attached to calendar invites weren't being captured
- Use native `event.Attachments` field from Calendar API instead of parsing description text

## Changes Made
- **Enhanced CalendarEvent model**: Added `Attachments []CalendarAttachment` field with proper API field mapping
- **Fixed ConvertToModel**: Now processes `event.Attachments` from Google Calendar API directly  
- **Simplified ConvertToModelWithDrive**: Removed unreliable Drive description parsing logic
- **Updated attachment display**: Calendar command now shows proper attachment info with titles and URLs
- **Fixed universal Item conversion**: Attachments properly converted in PKM target exports

## Technical Details
The Google Calendar API already includes attachment data in the `Event.Attachments` field - no special parameters needed. The core issue was that existing code completely ignored this field and tried to parse description text instead, which was unreliable.

## Test Plan
- [x] Code compiles successfully
- [x] Calendar command help works correctly  
- [x] Attachment display logic updated for `--include-details` flag
- [x] JSON output includes new attachment structure
- [ ] Test with actual calendar events containing attachments

🤖 Generated with [Claude Code](https://claude.ai/code)