### PR TITLE
fix: remove duplicate flag definitions in calendar command

### DIFF
--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -50,10 +50,7 @@ func init() {
 	
 	// Add flags for date range and options
 	calendarCmd.Flags().StringVar(&startDate, "start", "", "Start date (defaults to beginning of current week)")
-	calendarCmd.Flags().StringVar(&startDate, "start-date", "", "Start date (defaults to beginning of current week)")
 	calendarCmd.Flags().StringVar(&endDate, "end", "", "End date (defaults to end of today)")
-	calendarCmd.Flags().StringVar(&endDate, "end-date", "", "End date (defaults to end of today)")
-	calendarCmd.Flags().Int64Var(&maxResults, "max-results", 100, "Maximum number of events to retrieve")
 	calendarCmd.Flags().Int64Var(&maxResults, "limit", 100, "Maximum number of events to retrieve")
 	calendarCmd.Flags().StringVar(&outputFormat, "format", "table", "Output format (table, json)")
 	calendarCmd.Flags().BoolVar(&includeDetails, "include-details", false, "Include detailed meeting information (attendees, URLs, etc.)")


### PR DESCRIPTION
## Summary
- Removed duplicate flag definitions in the calendar command that bound multiple flag names to the same variables
- Simplified flag interface by keeping only the shorter, clearer flag names
- Eliminates user confusion about which flags to use

## Changes
- Removed `--start-date` flag (kept `--start`)
- Removed `--end-date` flag (kept `--end`)
- Removed `--max-results` flag (kept `--limit`)

## Test plan
- [ ] Verify `./pkm-sync calendar --start 2025-01-01 --end 2025-01-31` works correctly
- [ ] Verify `./pkm-sync calendar --limit 50` works correctly
- [ ] Confirm removed flags (`--start-date`, `--end-date`, `--max-results`) are no longer recognized

🤖 Generated with [Claude Code](https://claude.ai/code)