### PR TITLE
fix: correct google_meetings source type in default config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,7 +82,7 @@ func GetDefaultConfig() *models.Config {
 			},
 			"google_meetings": {
 				Enabled: true,
-				Type:    "google_meetings",
+				Type:    "google_calendar",
 				Google: models.GoogleSourceConfig{
 					CalendarID:        "primary",
 					DownloadDocs:      true,


### PR DESCRIPTION
## Summary
Fixes a bug in the default configuration template where the `google_meetings` source was created with an invalid type `"google_meetings"` instead of the supported type `"google_calendar"`.

## Problem
When users run `pkm-sync config init`, the generated configuration includes a `google_meetings` source with:
```yaml
google_meetings:
  enabled: true
  type: google_meetings  # ❌ Invalid - not a supported source type
```

This causes validation to fail with:
```
❌ Configuration validation failed: sources configuration error: 
   source 'google_meetings': unsupported source type: google_meetings
```

## Solution
Changed the default template to use the correct type:
```yaml
google_meetings:
  enabled: true
  type: google_calendar  # ✅ Valid - matches supported types
```

## Supported Source Types
- `google_calendar`
- `gmail`
- `slack`
- `jira`

## Impact
- Users can now successfully validate default configurations
- The source **name** `google_meetings` remains unchanged, allowing users to configure multiple calendar sources with different filters
- Backward compatible: only affects newly generated configs

## Testing
- [x] Configuration validation now passes
- [x] Verified supported types in `internal/config/config.go:263-278`

🤖 Generated with [Claude Code](https://claude.com/claude-code)