### PR TITLE
feat: implement universal sync command (#14)

### DIFF
--- a/cmd/gmail.go
+++ b/cmd/gmail.go
@@ -1,0 +1,514 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"pkm-sync/internal/config"
+	"pkm-sync/internal/sources/google"
+	"pkm-sync/internal/targets/logseq"
+	"pkm-sync/internal/targets/obsidian"
+	"pkm-sync/internal/transform"
+	"pkm-sync/pkg/interfaces"
+	"pkm-sync/pkg/models"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	gmailSourceName   string
+	gmailTargetName   string
+	gmailOutputDir    string
+	gmailSince        string
+	gmailDryRun       bool
+	gmailLimit        int
+	gmailOutputFormat string
+)
+
+var gmailCmd = &cobra.Command{
+	Use:   "gmail",
+	Short: "Sync Gmail emails to PKM systems",
+	Long: `Sync Gmail emails to PKM targets (obsidian, logseq, etc.)
+    
+Examples:
+  pkm-sync gmail --source gmail_work --target obsidian --output ./vault
+  pkm-sync gmail --source gmail_personal --target logseq --output ./graph --since 7d
+  pkm-sync gmail --source gmail_work --target obsidian --dry-run`,
+	RunE: runGmailCommand,
+}
+
+func init() {
+	rootCmd.AddCommand(gmailCmd)
+	gmailCmd.Flags().StringVar(&gmailSourceName, "source", "", "Gmail source (gmail_work, gmail_personal, etc.)")
+	gmailCmd.Flags().StringVar(&gmailTargetName, "target", "", "PKM target (obsidian, logseq)")
+	gmailCmd.Flags().StringVarP(&gmailOutputDir, "output", "o", "", "Output directory")
+	gmailCmd.Flags().StringVar(&gmailSince, "since", "", "Sync emails since (7d, 2006-01-02, today)")
+	gmailCmd.Flags().BoolVar(&gmailDryRun, "dry-run", false, "Show what would be synced without making changes")
+	gmailCmd.Flags().IntVar(&gmailLimit, "limit", 1000, "Maximum number of emails to fetch (default: 1000)")
+	gmailCmd.Flags().StringVar(&gmailOutputFormat, "format", "summary", "Output format for dry-run (summary, json)")
+}
+
+func runGmailCommand(cmd *cobra.Command, args []string) error {
+	// Load configuration
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		// If no config exists, use defaults
+		cfg = config.GetDefaultConfig()
+	}
+
+	// Determine which Gmail sources to sync
+	var sourcesToSync []string
+	if gmailSourceName != "" {
+		// CLI override: sync specific Gmail source
+		sourcesToSync = []string{gmailSourceName}
+	} else {
+		// Use enabled Gmail sources from config
+		sourcesToSync = getEnabledGmailSources(cfg)
+	}
+
+	if len(sourcesToSync) == 0 {
+		return fmt.Errorf("no Gmail sources configured. Please configure Gmail sources in your config file or use --source flag")
+	}
+
+	// Apply config defaults, then CLI overrides
+	finalTargetName := cfg.Sync.DefaultTarget
+	if gmailTargetName != "" {
+		finalTargetName = gmailTargetName
+	}
+
+	finalOutputDir := cfg.Sync.DefaultOutputDir
+	if gmailOutputDir != "" {
+		finalOutputDir = gmailOutputDir
+	}
+
+	finalSince := cfg.Sync.DefaultSince
+	if gmailSince != "" {
+		finalSince = gmailSince
+	}
+
+	// Parse since parameter
+	sinceTime, err := parseSinceTime(finalSince)
+	if err != nil {
+		return fmt.Errorf("invalid since parameter: %w", err)
+	}
+
+	fmt.Printf("Syncing Gmail from sources [%s] to %s (output: %s, since: %s)\n",
+		strings.Join(sourcesToSync, ", "), finalTargetName, finalOutputDir, finalSince)
+
+	// Create target with config
+	target, err := createTargetWithConfig(finalTargetName, cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create target: %w", err)
+	}
+
+	// Collect all items from all Gmail sources for unified processing
+	var allItems []models.ItemInterface
+
+	// Process each Gmail source independently to support per-source customization
+	for _, srcName := range sourcesToSync {
+		// Get source-specific config
+		sourceConfig, exists := cfg.Sources[srcName]
+		if !exists {
+			fmt.Printf("Warning: Gmail source '%s' not configured, skipping\n", srcName)
+
+			continue
+		}
+
+		if !sourceConfig.Enabled {
+			fmt.Printf("Gmail source '%s' is disabled, skipping\n", srcName)
+
+			continue
+		}
+
+		// Verify this is a Gmail source
+		if sourceConfig.Type != "gmail" {
+			fmt.Printf("Warning: source '%s' is not a Gmail source (type: %s), skipping\n", srcName, sourceConfig.Type)
+
+			continue
+		}
+
+		// Create source with config
+		source, err := createSourceWithConfig(srcName, sourceConfig, nil)
+		if err != nil {
+			fmt.Printf("Warning: failed to create Gmail source '%s': %v, skipping\n", srcName, err)
+
+			continue
+		}
+
+		// Use source-specific since time if configured, but CLI flag takes precedence
+		sourceSince := finalSince
+		if sourceConfig.Since != "" && gmailSince == "" {
+			// Only use config since if no CLI override was provided
+			sourceSince = sourceConfig.Since
+		}
+
+		sourceSinceTime, err := parseSinceTime(sourceSince)
+		if err != nil {
+			fmt.Printf("Warning: invalid since time for Gmail source '%s': %v, using default\n", srcName, err)
+
+			sourceSinceTime = sinceTime
+		}
+
+		// Use source-specific max results if configured, otherwise default to 1000
+		maxResults := 1000 // default value
+
+		if sourceConfig.Google.MaxResults > 0 {
+			// Validate max results range
+			if sourceConfig.Google.MaxResults > 2500 {
+				fmt.Printf("Warning: max_results for Gmail source '%s' is %d (maximum allowed: 2500), using 2500\n", srcName, sourceConfig.Google.MaxResults)
+
+				maxResults = 2500
+			} else {
+				maxResults = sourceConfig.Google.MaxResults
+			}
+		}
+
+		// Fetch items from this Gmail source
+		fmt.Printf("Fetching emails from %s...\n", srcName)
+
+		items, err := source.Fetch(sourceSinceTime, maxResults)
+		if err != nil {
+			fmt.Printf("Warning: failed to fetch from Gmail source '%s': %v, skipping\n", srcName, err)
+
+			continue
+		}
+
+		// Add source tags if enabled
+		if cfg.Sync.SourceTags {
+			for _, item := range items {
+				currentTags := item.GetTags()
+				newTags := append(currentTags, "source:"+srcName)
+				item.SetTags(newTags)
+			}
+		}
+
+		fmt.Printf("Found %d emails from %s\n", len(items), srcName)
+
+		// Add items to the collection
+		allItems = append(allItems, items...)
+	}
+
+	fmt.Printf("Total emails collected: %d\n", len(allItems))
+
+	// Initialize and apply transformer pipeline if configured
+	if cfg.Transformers.Enabled {
+		pipeline := transform.NewPipeline()
+
+		// Register all available transformers
+		for _, t := range transform.GetAllExampleTransformers() {
+			if err := pipeline.AddTransformer(t); err != nil {
+				return fmt.Errorf("failed to add transformer %s: %w", t.Name(), err)
+			}
+		}
+
+		// Configure the pipeline from the config file
+		if err := pipeline.Configure(cfg.Transformers); err != nil {
+			return fmt.Errorf("failed to configure transformer pipeline: %w", err)
+		}
+
+		// Transform items
+		transformedItems, err := pipeline.Transform(allItems)
+		if err != nil {
+			return fmt.Errorf("failed to transform items: %w", err)
+		}
+
+		fmt.Printf("Transformed to %d items\n", len(transformedItems))
+		allItems = transformedItems
+	}
+
+	if gmailDryRun {
+		// Generate preview of what would be done
+		previews, err := target.Preview(allItems, finalOutputDir)
+		if err != nil {
+			return fmt.Errorf("failed to generate preview: %w", err)
+		}
+
+		switch gmailOutputFormat {
+		case "json":
+			return outputDryRunJSON(allItems, previews, finalTargetName, finalOutputDir, sourcesToSync)
+		case "summary":
+			return outputDryRunSummary(allItems, previews, finalTargetName, finalOutputDir, sourcesToSync)
+		default:
+			return fmt.Errorf("unknown format '%s': supported formats are 'summary' and 'json'", gmailOutputFormat)
+		}
+	}
+
+	// Export all items to target
+	if err := target.Export(allItems, finalOutputDir); err != nil {
+		return fmt.Errorf("failed to export to target: %w", err)
+	}
+
+	fmt.Printf("Successfully exported %d emails\n", len(allItems))
+
+	return nil
+}
+
+func createSource(name string, client *http.Client) (interfaces.Source, error) {
+	switch name {
+	case "google_calendar":
+		source := google.NewGoogleSource()
+		if err := source.Configure(nil, client); err != nil {
+			return nil, err
+		}
+
+		return source, nil
+	default:
+		return nil, fmt.Errorf("unknown source '%s': supported sources are 'google_calendar' (others like slack, gmail, jira are planned for future releases)", name)
+	}
+}
+
+func createSourceWithConfig(sourceID string, sourceConfig models.SourceConfig, client *http.Client) (interfaces.Source, error) {
+	switch sourceConfig.Type {
+	case "google_calendar":
+		source := google.NewGoogleSourceWithConfig(sourceID, sourceConfig)
+		if err := source.Configure(nil, client); err != nil {
+			return nil, err
+		}
+
+		return source, nil
+	case "gmail":
+		source := google.NewGoogleSourceWithConfig(sourceID, sourceConfig)
+		if err := source.Configure(nil, client); err != nil {
+			return nil, err
+		}
+
+		return source, nil
+	default:
+		return nil, fmt.Errorf("unknown source type '%s': supported types are 'google_calendar', 'gmail' (others like slack, jira are planned for future releases)", sourceConfig.Type)
+	}
+}
+
+func createTarget(name string) (interfaces.Target, error) {
+	switch name {
+	case "obsidian":
+		target := obsidian.NewObsidianTarget()
+		if err := target.Configure(nil); err != nil {
+			return nil, err
+		}
+
+		return target, nil
+	case "logseq":
+		target := logseq.NewLogseqTarget()
+		if err := target.Configure(nil); err != nil {
+			return nil, err
+		}
+
+		return target, nil
+	default:
+		return nil, fmt.Errorf("unknown target '%s': supported targets are 'obsidian' and 'logseq'", name)
+	}
+}
+
+func createTargetWithConfig(name string, cfg *models.Config) (interfaces.Target, error) {
+	switch name {
+	case "obsidian":
+		target := obsidian.NewObsidianTarget()
+
+		// Apply configuration
+		configMap := make(map[string]interface{})
+		if targetConfig, exists := cfg.Targets[name]; exists {
+			configMap["template_dir"] = targetConfig.Obsidian.DefaultFolder
+			configMap["daily_notes_format"] = targetConfig.Obsidian.DateFormat
+		}
+
+		if err := target.Configure(configMap); err != nil {
+			return nil, err
+		}
+
+		return target, nil
+
+	case "logseq":
+		target := logseq.NewLogseqTarget()
+
+		// Apply configuration
+		configMap := make(map[string]interface{})
+		if targetConfig, exists := cfg.Targets[name]; exists {
+			configMap["default_page"] = targetConfig.Logseq.DefaultPage
+		}
+
+		if err := target.Configure(configMap); err != nil {
+			return nil, err
+		}
+
+		return target, nil
+
+	default:
+		return nil, fmt.Errorf("unknown target '%s': supported targets are 'obsidian' and 'logseq'", name)
+	}
+}
+
+func parseSinceTime(since string) (time.Time, error) {
+	// Delegate to the unified date parser
+	return parseDateTime(since)
+}
+
+// getEnabledSources returns list of sources that are enabled in the configuration.
+func getEnabledSources(cfg *models.Config) []string {
+	var enabledSources []string
+
+	// Use explicit enabled_sources list if provided
+	if len(cfg.Sync.EnabledSources) > 0 {
+		for _, srcName := range cfg.Sync.EnabledSources {
+			if sourceConfig, exists := cfg.Sources[srcName]; exists && sourceConfig.Enabled {
+				enabledSources = append(enabledSources, srcName)
+			}
+		}
+
+		return enabledSources
+	}
+
+	// Fallback: find all enabled sources in config
+	for srcName, sourceConfig := range cfg.Sources {
+		if sourceConfig.Enabled {
+			enabledSources = append(enabledSources, srcName)
+		}
+	}
+
+	return enabledSources
+}
+
+// getEnabledGmailSources returns list of Gmail sources that are enabled in the configuration.
+func getEnabledGmailSources(cfg *models.Config) []string {
+	var enabledSources []string
+
+	// Use explicit enabled_sources list if provided
+	if len(cfg.Sync.EnabledSources) > 0 {
+		for _, srcName := range cfg.Sync.EnabledSources {
+			if sourceConfig, exists := cfg.Sources[srcName]; exists && sourceConfig.Enabled && sourceConfig.Type == "gmail" {
+				enabledSources = append(enabledSources, srcName)
+			}
+		}
+
+		return enabledSources
+	}
+
+	// Fallback: find all enabled Gmail sources in config
+	for srcName, sourceConfig := range cfg.Sources {
+		if sourceConfig.Enabled && sourceConfig.Type == "gmail" {
+			enabledSources = append(enabledSources, srcName)
+		}
+	}
+
+	return enabledSources
+}
+
+// getSourceOutputDirectory calculates the output directory for a source based on configuration.
+func getSourceOutputDirectory(baseOutputDir string, sourceConfig models.SourceConfig) string {
+	if sourceConfig.OutputSubdir != "" {
+		return filepath.Join(baseOutputDir, sourceConfig.OutputSubdir)
+	}
+
+	return baseOutputDir
+}
+
+// DryRunOutput represents the complete output structure for JSON format.
+type DryRunOutput struct {
+	Target       string                    `json:"target"`
+	OutputDir    string                    `json:"output_dir"`
+	Sources      []string                  `json:"sources"`
+	TotalItems   int                       `json:"total_items"`
+	Summary      DryRunSummary             `json:"summary"`
+	Items        []models.ItemInterface    `json:"items"`
+	FilePreviews []*interfaces.FilePreview `json:"file_previews"`
+}
+
+type DryRunSummary struct {
+	CreateCount   int `json:"create_count"`
+	UpdateCount   int `json:"update_count"`
+	SkipCount     int `json:"skip_count"`
+	ConflictCount int `json:"conflict_count"`
+}
+
+func outputDryRunJSON(items []models.ItemInterface, previews []*interfaces.FilePreview, target, outputDir string, sources []string) error {
+	summary := calculateSummary(previews)
+
+	output := DryRunOutput{
+		Target:       target,
+		OutputDir:    outputDir,
+		Sources:      sources,
+		TotalItems:   len(items),
+		Summary:      summary,
+		Items:        items,
+		FilePreviews: previews,
+	}
+
+	jsonData, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+
+	fmt.Println(string(jsonData))
+
+	return nil
+}
+
+func outputDryRunSummary(items []models.ItemInterface, previews []*interfaces.FilePreview, target, outputDir string, _ []string) error {
+	fmt.Printf("=== DRY RUN: Preview of sync operation ===\n")
+	fmt.Printf("Target: %s\nOutput directory: %s\nTotal items: %d\n\n", target, outputDir, len(items))
+
+	summary := calculateSummary(previews)
+
+	fmt.Printf("Summary:\n")
+	fmt.Printf("  📝 %d files would be created\n", summary.CreateCount)
+	fmt.Printf("  ✏️  %d files would be updated\n", summary.UpdateCount)
+	fmt.Printf("  ⏭️  %d files would be skipped (no changes)\n", summary.SkipCount)
+
+	if summary.ConflictCount > 0 {
+		fmt.Printf("  ⚠️  %d files have potential conflicts\n", summary.ConflictCount)
+	}
+
+	fmt.Printf("\n")
+
+	// Show detailed file operations
+	fmt.Printf("Detailed file operations:\n")
+
+	for _, preview := range previews {
+		var emoji string
+
+		switch preview.Action {
+		case "update":
+			emoji = "✏️"
+		case "skip":
+			emoji = "⏭️"
+		default:
+			emoji = "📝"
+		}
+
+		if preview.Conflict {
+			emoji = "⚠️"
+		}
+
+		fmt.Printf("  %s %s %s\n", emoji, preview.Action, preview.FilePath)
+	}
+
+	// Ask if user wants to see file content previews
+	fmt.Printf("\nWould you like to see content previews? This will show the first few lines of each file that would be created/updated.\n")
+	fmt.Printf("Note: Use --format json to see complete data model including full content\n")
+
+	return nil
+}
+
+func calculateSummary(previews []*interfaces.FilePreview) DryRunSummary {
+	summary := DryRunSummary{}
+
+	for _, preview := range previews {
+		switch preview.Action {
+		case "create":
+			summary.CreateCount++
+		case "update":
+			summary.UpdateCount++
+		case "skip":
+			summary.SkipCount++
+		}
+
+		if preview.Conflict {
+			summary.ConflictCount++
+		}
+	}
+
+	return summary
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ var rootCmd = &cobra.Command{
 with Personal Knowledge Management systems (Obsidian, Logseq, etc.).
 
 Commands:
+  sync      Sync all enabled sources to PKM systems
   gmail     Sync Gmail emails to PKM systems
   drive     Export Google Drive documents to markdown
   calendar  List and sync Google Calendar events

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -1,165 +1,163 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"path/filepath"
 	"strings"
-	"time"
 
 	"pkm-sync/internal/config"
-	"pkm-sync/internal/sources/google"
-	"pkm-sync/internal/targets/logseq"
-	"pkm-sync/internal/targets/obsidian"
 	"pkm-sync/internal/transform"
-	"pkm-sync/pkg/interfaces"
 	"pkm-sync/pkg/models"
 
 	"github.com/spf13/cobra"
 )
 
 var (
-	gmailSourceName   string
-	gmailTargetName   string
-	gmailOutputDir    string
-	gmailSince        string
-	gmailDryRun       bool
-	gmailLimit        int
-	gmailOutputFormat string
+	syncSourceName   string
+	syncTargetName   string
+	syncOutputDir    string
+	syncSince        string
+	syncDryRun       bool
+	syncLimit        int
+	syncOutputFormat string
 )
 
-var gmailCmd = &cobra.Command{
-	Use:   "gmail",
-	Short: "Sync Gmail emails to PKM systems",
-	Long: `Sync Gmail emails to PKM targets (obsidian, logseq, etc.)
-    
+var syncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Sync all enabled sources to PKM systems",
+	Long: `Sync all enabled sources (Gmail, Google Calendar, etc.) to PKM targets in a single operation.
+
 Examples:
-  pkm-sync gmail --source gmail_work --target obsidian --output ./vault
-  pkm-sync gmail --source gmail_personal --target logseq --output ./graph --since 7d
-  pkm-sync gmail --source gmail_work --target obsidian --dry-run`,
-	RunE: runGmailCommand,
+  pkm-sync sync
+  pkm-sync sync --source gmail_work
+  pkm-sync sync --target obsidian --output ./vault
+  pkm-sync sync --since 7d --dry-run
+  pkm-sync sync --source gmail_work --dry-run --format json`,
+	RunE: runSyncCommand,
 }
 
 func init() {
-	rootCmd.AddCommand(gmailCmd)
-	gmailCmd.Flags().StringVar(&gmailSourceName, "source", "", "Gmail source (gmail_work, gmail_personal, etc.)")
-	gmailCmd.Flags().StringVar(&gmailTargetName, "target", "", "PKM target (obsidian, logseq)")
-	gmailCmd.Flags().StringVarP(&gmailOutputDir, "output", "o", "", "Output directory")
-	gmailCmd.Flags().StringVar(&gmailSince, "since", "", "Sync emails since (7d, 2006-01-02, today)")
-	gmailCmd.Flags().BoolVar(&gmailDryRun, "dry-run", false, "Show what would be synced without making changes")
-	gmailCmd.Flags().IntVar(&gmailLimit, "limit", 1000, "Maximum number of emails to fetch (default: 1000)")
-	gmailCmd.Flags().StringVar(&gmailOutputFormat, "format", "summary", "Output format for dry-run (summary, json)")
+	rootCmd.AddCommand(syncCmd)
+	syncCmd.Flags().StringVar(&syncSourceName, "source", "", "Filter to a specific source by name")
+	syncCmd.Flags().StringVar(&syncTargetName, "target", "", "PKM target (obsidian, logseq)")
+	syncCmd.Flags().StringVarP(&syncOutputDir, "output", "o", "", "Output directory")
+	syncCmd.Flags().StringVar(&syncSince, "since", "", "Sync items since (7d, 2006-01-02, today)")
+	syncCmd.Flags().BoolVar(&syncDryRun, "dry-run", false, "Show what would be synced without making changes")
+	syncCmd.Flags().IntVar(&syncLimit, "limit", 1000, "Maximum number of items per source")
+	syncCmd.Flags().StringVar(&syncOutputFormat, "format", "summary", "Output format for dry-run (summary, json)")
 }
 
-func runGmailCommand(cmd *cobra.Command, args []string) error {
+// sourceResult tracks the outcome of syncing a single source.
+type sourceResult struct {
+	Name      string
+	ItemCount int
+	Err       error
+}
+
+func runSyncCommand(cmd *cobra.Command, args []string) error {
 	// Load configuration
 	cfg, err := config.LoadConfig()
 	if err != nil {
-		// If no config exists, use defaults
 		cfg = config.GetDefaultConfig()
 	}
 
-	// Determine which Gmail sources to sync
+	// Determine which sources to sync
 	var sourcesToSync []string
-	if gmailSourceName != "" {
-		// CLI override: sync specific Gmail source
-		sourcesToSync = []string{gmailSourceName}
+	if syncSourceName != "" {
+		sourcesToSync = []string{syncSourceName}
 	} else {
-		// Use enabled Gmail sources from config
-		sourcesToSync = getEnabledGmailSources(cfg)
+		sourcesToSync = getEnabledSources(cfg)
 	}
 
 	if len(sourcesToSync) == 0 {
-		return fmt.Errorf("no Gmail sources configured. Please configure Gmail sources in your config file or use --source flag")
+		return fmt.Errorf("no enabled sources found. Configure sources in your config file or use --source flag")
 	}
 
-	// Apply config defaults, then CLI overrides
+	// Resolve target, output, and since from CLI flags with config fallbacks
 	finalTargetName := cfg.Sync.DefaultTarget
-	if gmailTargetName != "" {
-		finalTargetName = gmailTargetName
+	if syncTargetName != "" {
+		finalTargetName = syncTargetName
 	}
 
 	finalOutputDir := cfg.Sync.DefaultOutputDir
-	if gmailOutputDir != "" {
-		finalOutputDir = gmailOutputDir
+	if syncOutputDir != "" {
+		finalOutputDir = syncOutputDir
 	}
 
 	finalSince := cfg.Sync.DefaultSince
-	if gmailSince != "" {
-		finalSince = gmailSince
+	if syncSince != "" {
+		finalSince = syncSince
 	}
 
-	// Parse since parameter
-	sinceTime, err := parseSinceTime(finalSince)
+	// Parse the default since time (used as fallback for per-source since)
+	defaultSinceTime, err := parseSinceTime(finalSince)
 	if err != nil {
 		return fmt.Errorf("invalid since parameter: %w", err)
 	}
 
-	fmt.Printf("Syncing Gmail from sources [%s] to %s (output: %s, since: %s)\n",
+	fmt.Printf("Syncing sources [%s] to %s (output: %s, since: %s)\n",
 		strings.Join(sourcesToSync, ", "), finalTargetName, finalOutputDir, finalSince)
 
-	// Create target with config
+	// Create target — fatal on failure since we need somewhere to write
 	target, err := createTargetWithConfig(finalTargetName, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to create target: %w", err)
 	}
 
-	// Collect all items from all Gmail sources for unified processing
+	// Collect all items across all sources
 	var allItems []models.ItemInterface
 
-	// Process each Gmail source independently to support per-source customization
+	var results []sourceResult
+
 	for _, srcName := range sourcesToSync {
-		// Get source-specific config
 		sourceConfig, exists := cfg.Sources[srcName]
 		if !exists {
-			fmt.Printf("Warning: Gmail source '%s' not configured, skipping\n", srcName)
+			fmt.Printf("Warning: source '%s' not configured, skipping\n", srcName)
+			results = append(results, sourceResult{Name: srcName, Err: fmt.Errorf("not configured")})
 
 			continue
 		}
 
 		if !sourceConfig.Enabled {
-			fmt.Printf("Gmail source '%s' is disabled, skipping\n", srcName)
+			fmt.Printf("Source '%s' is disabled, skipping\n", srcName)
 
 			continue
 		}
 
-		// Verify this is a Gmail source
-		if sourceConfig.Type != "gmail" {
-			fmt.Printf("Warning: source '%s' is not a Gmail source (type: %s), skipping\n", srcName, sourceConfig.Type)
+		// Only support source types that implement the Source interface
+		if sourceConfig.Type != "gmail" && sourceConfig.Type != "google_calendar" {
+			fmt.Printf("Warning: source '%s' has unsupported type '%s', skipping\n", srcName, sourceConfig.Type)
+			results = append(results, sourceResult{Name: srcName, Err: fmt.Errorf("unsupported type '%s'", sourceConfig.Type)})
 
 			continue
 		}
 
-		// Create source with config
 		source, err := createSourceWithConfig(srcName, sourceConfig, nil)
 		if err != nil {
-			fmt.Printf("Warning: failed to create Gmail source '%s': %v, skipping\n", srcName, err)
+			fmt.Printf("Warning: failed to create source '%s': %v, skipping\n", srcName, err)
+			results = append(results, sourceResult{Name: srcName, Err: err})
 
 			continue
 		}
 
-		// Use source-specific since time if configured, but CLI flag takes precedence
+		// Per-source since: config overrides default, but CLI flag takes precedence over both
 		sourceSince := finalSince
-		if sourceConfig.Since != "" && gmailSince == "" {
-			// Only use config since if no CLI override was provided
+		if sourceConfig.Since != "" && syncSince == "" {
 			sourceSince = sourceConfig.Since
 		}
 
 		sourceSinceTime, err := parseSinceTime(sourceSince)
 		if err != nil {
-			fmt.Printf("Warning: invalid since time for Gmail source '%s': %v, using default\n", srcName, err)
+			fmt.Printf("Warning: invalid since time for source '%s': %v, using default\n", srcName, err)
 
-			sourceSinceTime = sinceTime
+			sourceSinceTime = defaultSinceTime
 		}
 
-		// Use source-specific max results if configured, otherwise default to 1000
-		maxResults := 1000 // default value
+		// Per-source max results with a cap at 2500
+		maxResults := syncLimit
 
 		if sourceConfig.Google.MaxResults > 0 {
-			// Validate max results range
 			if sourceConfig.Google.MaxResults > 2500 {
-				fmt.Printf("Warning: max_results for Gmail source '%s' is %d (maximum allowed: 2500), using 2500\n", srcName, sourceConfig.Google.MaxResults)
+				fmt.Printf("Warning: max_results for source '%s' is %d (maximum: 2500), capping\n", srcName, sourceConfig.Google.MaxResults)
 
 				maxResults = 2500
 			} else {
@@ -167,50 +165,45 @@ func runGmailCommand(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		// Fetch items from this Gmail source
-		fmt.Printf("Fetching emails from %s...\n", srcName)
+		fmt.Printf("Fetching items from %s...\n", srcName)
 
 		items, err := source.Fetch(sourceSinceTime, maxResults)
 		if err != nil {
-			fmt.Printf("Warning: failed to fetch from Gmail source '%s': %v, skipping\n", srcName, err)
+			fmt.Printf("Warning: failed to fetch from source '%s': %v, skipping\n", srcName, err)
+			results = append(results, sourceResult{Name: srcName, Err: err})
 
 			continue
 		}
 
-		// Add source tags if enabled
+		// Apply source tags if enabled
 		if cfg.Sync.SourceTags {
 			for _, item := range items {
 				currentTags := item.GetTags()
-				newTags := append(currentTags, "source:"+srcName)
-				item.SetTags(newTags)
+				item.SetTags(append(currentTags, "source:"+srcName))
 			}
 		}
 
-		fmt.Printf("Found %d emails from %s\n", len(items), srcName)
-
-		// Add items to the collection
+		fmt.Printf("Found %d items from %s\n", len(items), srcName)
+		results = append(results, sourceResult{Name: srcName, ItemCount: len(items)})
 		allItems = append(allItems, items...)
 	}
 
-	fmt.Printf("Total emails collected: %d\n", len(allItems))
+	fmt.Printf("Total items collected: %d\n", len(allItems))
 
-	// Initialize and apply transformer pipeline if configured
+	// Apply transformer pipeline if configured
 	if cfg.Transformers.Enabled {
 		pipeline := transform.NewPipeline()
 
-		// Register all available transformers
 		for _, t := range transform.GetAllExampleTransformers() {
 			if err := pipeline.AddTransformer(t); err != nil {
 				return fmt.Errorf("failed to add transformer %s: %w", t.Name(), err)
 			}
 		}
 
-		// Configure the pipeline from the config file
 		if err := pipeline.Configure(cfg.Transformers); err != nil {
 			return fmt.Errorf("failed to configure transformer pipeline: %w", err)
 		}
 
-		// Transform items
 		transformedItems, err := pipeline.Transform(allItems)
 		if err != nil {
 			return fmt.Errorf("failed to transform items: %w", err)
@@ -220,295 +213,55 @@ func runGmailCommand(cmd *cobra.Command, args []string) error {
 		allItems = transformedItems
 	}
 
-	if gmailDryRun {
-		// Generate preview of what would be done
+	if syncDryRun {
 		previews, err := target.Preview(allItems, finalOutputDir)
 		if err != nil {
 			return fmt.Errorf("failed to generate preview: %w", err)
 		}
 
-		switch gmailOutputFormat {
+		switch syncOutputFormat {
 		case "json":
 			return outputDryRunJSON(allItems, previews, finalTargetName, finalOutputDir, sourcesToSync)
 		case "summary":
 			return outputDryRunSummary(allItems, previews, finalTargetName, finalOutputDir, sourcesToSync)
 		default:
-			return fmt.Errorf("unknown format '%s': supported formats are 'summary' and 'json'", gmailOutputFormat)
+			return fmt.Errorf("unknown format '%s': supported formats are 'summary' and 'json'", syncOutputFormat)
 		}
 	}
 
-	// Export all items to target
 	if err := target.Export(allItems, finalOutputDir); err != nil {
 		return fmt.Errorf("failed to export to target: %w", err)
 	}
 
-	fmt.Printf("Successfully exported %d emails\n", len(allItems))
+	// Print summary
+	printSyncSummary(results, len(allItems))
 
 	return nil
 }
 
-func createSource(name string, client *http.Client) (interfaces.Source, error) {
-	switch name {
-	case "google_calendar":
-		source := google.NewGoogleSource()
-		if err := source.Configure(nil, client); err != nil {
-			return nil, err
-		}
+func printSyncSummary(results []sourceResult, totalItems int) {
+	attempted := len(results)
+	succeeded := 0
+	failed := 0
 
-		return source, nil
-	default:
-		return nil, fmt.Errorf("unknown source '%s': supported sources are 'google_calendar' (others like slack, gmail, jira are planned for future releases)", name)
+	for _, r := range results {
+		if r.Err != nil {
+			failed++
+		} else {
+			succeeded++
+		}
 	}
-}
 
-func createSourceWithConfig(sourceID string, sourceConfig models.SourceConfig, client *http.Client) (interfaces.Source, error) {
-	switch sourceConfig.Type {
-	case "google_calendar":
-		source := google.NewGoogleSourceWithConfig(sourceID, sourceConfig)
-		if err := source.Configure(nil, client); err != nil {
-			return nil, err
-		}
+	fmt.Printf("\nSync complete: %d sources attempted, %d succeeded, %d failed\n", attempted, succeeded, failed)
+	fmt.Printf("Total items exported: %d\n", totalItems)
 
-		return source, nil
-	case "gmail":
-		source := google.NewGoogleSourceWithConfig(sourceID, sourceConfig)
-		if err := source.Configure(nil, client); err != nil {
-			return nil, err
-		}
+	if failed > 0 {
+		fmt.Printf("\nFailed sources:\n")
 
-		return source, nil
-	default:
-		return nil, fmt.Errorf("unknown source type '%s': supported types are 'google_calendar', 'gmail' (others like slack, jira are planned for future releases)", sourceConfig.Type)
-	}
-}
-
-func createTarget(name string) (interfaces.Target, error) {
-	switch name {
-	case "obsidian":
-		target := obsidian.NewObsidianTarget()
-		if err := target.Configure(nil); err != nil {
-			return nil, err
-		}
-
-		return target, nil
-	case "logseq":
-		target := logseq.NewLogseqTarget()
-		if err := target.Configure(nil); err != nil {
-			return nil, err
-		}
-
-		return target, nil
-	default:
-		return nil, fmt.Errorf("unknown target '%s': supported targets are 'obsidian' and 'logseq'", name)
-	}
-}
-
-func createTargetWithConfig(name string, cfg *models.Config) (interfaces.Target, error) {
-	switch name {
-	case "obsidian":
-		target := obsidian.NewObsidianTarget()
-
-		// Apply configuration
-		configMap := make(map[string]interface{})
-		if targetConfig, exists := cfg.Targets[name]; exists {
-			configMap["template_dir"] = targetConfig.Obsidian.DefaultFolder
-			configMap["daily_notes_format"] = targetConfig.Obsidian.DateFormat
-		}
-
-		if err := target.Configure(configMap); err != nil {
-			return nil, err
-		}
-
-		return target, nil
-
-	case "logseq":
-		target := logseq.NewLogseqTarget()
-
-		// Apply configuration
-		configMap := make(map[string]interface{})
-		if targetConfig, exists := cfg.Targets[name]; exists {
-			configMap["default_page"] = targetConfig.Logseq.DefaultPage
-		}
-
-		if err := target.Configure(configMap); err != nil {
-			return nil, err
-		}
-
-		return target, nil
-
-	default:
-		return nil, fmt.Errorf("unknown target '%s': supported targets are 'obsidian' and 'logseq'", name)
-	}
-}
-
-func parseSinceTime(since string) (time.Time, error) {
-	// Delegate to the unified date parser
-	return parseDateTime(since)
-}
-
-// getEnabledSources returns list of sources that are enabled in the configuration.
-func getEnabledSources(cfg *models.Config) []string {
-	var enabledSources []string
-
-	// Use explicit enabled_sources list if provided
-	if len(cfg.Sync.EnabledSources) > 0 {
-		for _, srcName := range cfg.Sync.EnabledSources {
-			if sourceConfig, exists := cfg.Sources[srcName]; exists && sourceConfig.Enabled {
-				enabledSources = append(enabledSources, srcName)
+		for _, r := range results {
+			if r.Err != nil {
+				fmt.Printf("  - %s: %v\n", r.Name, r.Err)
 			}
 		}
-
-		return enabledSources
 	}
-
-	// Fallback: find all enabled sources in config
-	for srcName, sourceConfig := range cfg.Sources {
-		if sourceConfig.Enabled {
-			enabledSources = append(enabledSources, srcName)
-		}
-	}
-
-	return enabledSources
-}
-
-// getEnabledGmailSources returns list of Gmail sources that are enabled in the configuration.
-func getEnabledGmailSources(cfg *models.Config) []string {
-	var enabledSources []string
-
-	// Use explicit enabled_sources list if provided
-	if len(cfg.Sync.EnabledSources) > 0 {
-		for _, srcName := range cfg.Sync.EnabledSources {
-			if sourceConfig, exists := cfg.Sources[srcName]; exists && sourceConfig.Enabled && sourceConfig.Type == "gmail" {
-				enabledSources = append(enabledSources, srcName)
-			}
-		}
-
-		return enabledSources
-	}
-
-	// Fallback: find all enabled Gmail sources in config
-	for srcName, sourceConfig := range cfg.Sources {
-		if sourceConfig.Enabled && sourceConfig.Type == "gmail" {
-			enabledSources = append(enabledSources, srcName)
-		}
-	}
-
-	return enabledSources
-}
-
-// getSourceOutputDirectory calculates the output directory for a source based on configuration.
-func getSourceOutputDirectory(baseOutputDir string, sourceConfig models.SourceConfig) string {
-	if sourceConfig.OutputSubdir != "" {
-		return filepath.Join(baseOutputDir, sourceConfig.OutputSubdir)
-	}
-
-	return baseOutputDir
-}
-
-// DryRunOutput represents the complete output structure for JSON format.
-type DryRunOutput struct {
-	Target       string                    `json:"target"`
-	OutputDir    string                    `json:"output_dir"`
-	Sources      []string                  `json:"sources"`
-	TotalItems   int                       `json:"total_items"`
-	Summary      DryRunSummary             `json:"summary"`
-	Items        []models.ItemInterface    `json:"items"`
-	FilePreviews []*interfaces.FilePreview `json:"file_previews"`
-}
-
-type DryRunSummary struct {
-	CreateCount   int `json:"create_count"`
-	UpdateCount   int `json:"update_count"`
-	SkipCount     int `json:"skip_count"`
-	ConflictCount int `json:"conflict_count"`
-}
-
-func outputDryRunJSON(items []models.ItemInterface, previews []*interfaces.FilePreview, target, outputDir string, sources []string) error {
-	summary := calculateSummary(previews)
-
-	output := DryRunOutput{
-		Target:       target,
-		OutputDir:    outputDir,
-		Sources:      sources,
-		TotalItems:   len(items),
-		Summary:      summary,
-		Items:        items,
-		FilePreviews: previews,
-	}
-
-	jsonData, err := json.MarshalIndent(output, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %w", err)
-	}
-
-	fmt.Println(string(jsonData))
-
-	return nil
-}
-
-func outputDryRunSummary(items []models.ItemInterface, previews []*interfaces.FilePreview, target, outputDir string, _ []string) error {
-	fmt.Printf("=== DRY RUN: Preview of sync operation ===\n")
-	fmt.Printf("Target: %s\nOutput directory: %s\nTotal items: %d\n\n", target, outputDir, len(items))
-
-	summary := calculateSummary(previews)
-
-	fmt.Printf("Summary:\n")
-	fmt.Printf("  📝 %d files would be created\n", summary.CreateCount)
-	fmt.Printf("  ✏️  %d files would be updated\n", summary.UpdateCount)
-	fmt.Printf("  ⏭️  %d files would be skipped (no changes)\n", summary.SkipCount)
-
-	if summary.ConflictCount > 0 {
-		fmt.Printf("  ⚠️  %d files have potential conflicts\n", summary.ConflictCount)
-	}
-
-	fmt.Printf("\n")
-
-	// Show detailed file operations
-	fmt.Printf("Detailed file operations:\n")
-
-	for _, preview := range previews {
-		var emoji string
-
-		switch preview.Action {
-		case "update":
-			emoji = "✏️"
-		case "skip":
-			emoji = "⏭️"
-		default:
-			emoji = "📝"
-		}
-
-		if preview.Conflict {
-			emoji = "⚠️"
-		}
-
-		fmt.Printf("  %s %s %s\n", emoji, preview.Action, preview.FilePath)
-	}
-
-	// Ask if user wants to see file content previews
-	fmt.Printf("\nWould you like to see content previews? This will show the first few lines of each file that would be created/updated.\n")
-	fmt.Printf("Note: Use --format json to see complete data model including full content\n")
-
-	return nil
-}
-
-func calculateSummary(previews []*interfaces.FilePreview) DryRunSummary {
-	summary := DryRunSummary{}
-
-	for _, preview := range previews {
-		switch preview.Action {
-		case "create":
-			summary.CreateCount++
-		case "update":
-			summary.UpdateCount++
-		case "skip":
-			summary.SkipCount++
-		}
-
-		if preview.Conflict {
-			summary.ConflictCount++
-		}
-	}
-
-	return summary
 }

--- a/cmd/sync_cmd_test.go
+++ b/cmd/sync_cmd_test.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"pkm-sync/pkg/models"
+)
+
+func TestSyncCmd_SourceFiltering(t *testing.T) {
+	// When --source is set, only that source should be synced
+	cfg := &models.Config{
+		Sync: models.SyncConfig{
+			EnabledSources: []string{"gmail_work", "gmail_personal", "google_calendar"},
+		},
+		Sources: map[string]models.SourceConfig{
+			"gmail_work": {
+				Enabled: true,
+				Type:    "gmail",
+			},
+			"gmail_personal": {
+				Enabled: true,
+				Type:    "gmail",
+			},
+			"google_calendar": {
+				Enabled: true,
+				Type:    "google_calendar",
+			},
+		},
+	}
+
+	// Simulate --source flag filtering: only return the requested source
+	requestedSource := "gmail_work"
+	sourcesToSync := []string{requestedSource}
+
+	// Verify filtering result
+	if len(sourcesToSync) != 1 {
+		t.Errorf("Expected 1 source when --source is set, got %d", len(sourcesToSync))
+	}
+
+	if sourcesToSync[0] != requestedSource {
+		t.Errorf("Expected source %s, got %s", requestedSource, sourcesToSync[0])
+	}
+
+	// Verify the source exists and is enabled in config
+	srcCfg, exists := cfg.Sources[requestedSource]
+	if !exists {
+		t.Errorf("Expected source '%s' to exist in config", requestedSource)
+	}
+
+	if !srcCfg.Enabled {
+		t.Errorf("Expected source '%s' to be enabled", requestedSource)
+	}
+}
+
+func TestSyncCmd_ConfigResolutionCascade(t *testing.T) {
+	// CLI flags override config defaults
+	cfg := &models.Config{
+		Sync: models.SyncConfig{
+			DefaultTarget:    "obsidian",
+			DefaultOutputDir: "/default/output",
+			DefaultSince:     "7d",
+		},
+	}
+
+	// Case 1: No CLI overrides — use config defaults
+	finalTarget := cfg.Sync.DefaultTarget
+	finalOutput := cfg.Sync.DefaultOutputDir
+	finalSince := cfg.Sync.DefaultSince
+
+	if finalTarget != "obsidian" {
+		t.Errorf("Expected target 'obsidian', got '%s'", finalTarget)
+	}
+
+	if finalOutput != "/default/output" {
+		t.Errorf("Expected output '/default/output', got '%s'", finalOutput)
+	}
+
+	if finalSince != "7d" {
+		t.Errorf("Expected since '7d', got '%s'", finalSince)
+	}
+
+	// Case 2: CLI overrides apply
+	cliTarget := "logseq"
+	cliOutput := "/custom/output"
+	cliSince := "1d"
+
+	if cliTarget != "" {
+		finalTarget = cliTarget
+	}
+
+	if cliOutput != "" {
+		finalOutput = cliOutput
+	}
+
+	if cliSince != "" {
+		finalSince = cliSince
+	}
+
+	if finalTarget != "logseq" {
+		t.Errorf("Expected CLI override target 'logseq', got '%s'", finalTarget)
+	}
+
+	if finalOutput != "/custom/output" {
+		t.Errorf("Expected CLI override output '/custom/output', got '%s'", finalOutput)
+	}
+
+	if finalSince != "1d" {
+		t.Errorf("Expected CLI override since '1d', got '%s'", finalSince)
+	}
+}
+
+func TestSyncCmd_ErrorAccumulation(t *testing.T) {
+	// Source failures are tracked but don't stop the overall sync
+	results := []sourceResult{
+		{Name: "gmail_work", ItemCount: 5, Err: nil},
+		{Name: "gmail_personal", ItemCount: 0, Err: fmt.Errorf("auth error")},
+		{Name: "google_calendar", ItemCount: 3, Err: nil},
+	}
+
+	succeeded := 0
+	failed := 0
+
+	for _, r := range results {
+		if r.Err != nil {
+			failed++
+		} else {
+			succeeded++
+		}
+	}
+
+	if succeeded != 2 {
+		t.Errorf("Expected 2 succeeded sources, got %d", succeeded)
+	}
+
+	if failed != 1 {
+		t.Errorf("Expected 1 failed source, got %d", failed)
+	}
+}
+
+func TestSyncCmd_UnsupportedSourceType(t *testing.T) {
+	// drive and other unimplemented types should be skipped with a warning
+	supportedTypes := map[string]bool{
+		"gmail":           true,
+		"google_calendar": true,
+	}
+
+	unsupportedTypes := []string{"drive", "slack", "jira", "notion"}
+
+	for _, sourceType := range unsupportedTypes {
+		if supportedTypes[sourceType] {
+			t.Errorf("Expected source type '%s' to be unsupported", sourceType)
+		}
+	}
+
+	// Supported types should be recognized
+	for sourceType := range supportedTypes {
+		if !supportedTypes[sourceType] {
+			t.Errorf("Expected source type '%s' to be supported", sourceType)
+		}
+	}
+}
+
+func TestSyncCmd_SourceResultSummary(t *testing.T) {
+	tests := []struct {
+		name              string
+		results           []sourceResult
+		totalItems        int
+		expectedSucceeded int
+		expectedFailed    int
+	}{
+		{
+			name: "all sources succeed",
+			results: []sourceResult{
+				{Name: "gmail_work", ItemCount: 10, Err: nil},
+				{Name: "google_calendar", ItemCount: 5, Err: nil},
+			},
+			totalItems:        15,
+			expectedSucceeded: 2,
+			expectedFailed:    0,
+		},
+		{
+			name: "all sources fail",
+			results: []sourceResult{
+				{Name: "gmail_work", ItemCount: 0, Err: fmt.Errorf("error")},
+				{Name: "google_calendar", ItemCount: 0, Err: fmt.Errorf("error")},
+			},
+			totalItems:        0,
+			expectedSucceeded: 0,
+			expectedFailed:    2,
+		},
+		{
+			name: "mixed results",
+			results: []sourceResult{
+				{Name: "gmail_work", ItemCount: 8, Err: nil},
+				{Name: "gmail_personal", ItemCount: 0, Err: fmt.Errorf("token expired")},
+				{Name: "google_calendar", ItemCount: 3, Err: nil},
+			},
+			totalItems:        11,
+			expectedSucceeded: 2,
+			expectedFailed:    1,
+		},
+		{
+			name:              "empty results",
+			results:           []sourceResult{},
+			totalItems:        0,
+			expectedSucceeded: 0,
+			expectedFailed:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			succeeded := 0
+			failed := 0
+
+			for _, r := range tt.results {
+				if r.Err != nil {
+					failed++
+				} else {
+					succeeded++
+				}
+			}
+
+			if succeeded != tt.expectedSucceeded {
+				t.Errorf("Expected %d succeeded, got %d", tt.expectedSucceeded, succeeded)
+			}
+
+			if failed != tt.expectedFailed {
+				t.Errorf("Expected %d failed, got %d", tt.expectedFailed, failed)
+			}
+		})
+	}
+}
+
+func TestSyncCmd_PerSourceSinceResolution(t *testing.T) {
+	// Per-source since: config overrides global default, but CLI flag takes precedence
+	globalSince := "7d"
+	sourceConfigSince := "30d"
+
+	// Case 1: No CLI override — use source-specific config since
+	cliSince := ""
+	expectedSince := globalSince
+
+	if sourceConfigSince != "" && cliSince == "" {
+		expectedSince = sourceConfigSince
+	}
+
+	if expectedSince != sourceConfigSince {
+		t.Errorf("Expected source config since '%s', got '%s'", sourceConfigSince, expectedSince)
+	}
+
+	// Case 2: CLI override takes precedence over source config
+	cliSince = "1d"
+	expectedSince = globalSince
+
+	if cliSince != "" {
+		expectedSince = cliSince
+	} else if sourceConfigSince != "" {
+		expectedSince = sourceConfigSince
+	}
+
+	if expectedSince != cliSince {
+		t.Errorf("Expected CLI since '%s' to take precedence, got '%s'", cliSince, expectedSince)
+	}
+}


### PR DESCRIPTION
## Summary

- Rename `cmd/sync.go` → `cmd/gmail.go` (the Gmail command was living in a misnamed file)
- Add new `cmd/sync.go` implementing a universal `sync` command that processes all enabled sources in a single operation
- Update `cmd/root.go` to list `sync` in the Long description
- Add `cmd/sync_cmd_test.go` with 6 tests

## What the `sync` command does

- Processes all enabled sources (`gmail`, `google_calendar`) in one run
- `--source` flag filters to a single named source
- `--target`, `--output`, `--since`, `--limit`, `--format` flags override config defaults
- Per-source `since` from config is respected unless `--since` is passed on CLI
- Source failures are accumulated (don't stop the overall sync); a summary is printed at the end
- Transformer pipeline is applied if configured
- `--dry-run` supports both `summary` and `json` output formats
- Reuses all helper functions from `cmd/gmail.go` (same package)

## Test plan

- [x] `make ci` passes (lint, tests, build)
- [x] `./pkm-sync sync --help` shows correct usage and all flags
- [x] `./pkm-sync gmail --help` still works as before
- [x] All existing tests pass after the rename

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)