### PR TITLE
feat: make Google Drive a first-class sync source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ go build -o pkm-sync ./cmd     # Build named binary
 ./pkm-sync setup             # Verify authentication configuration
 ./pkm-sync gmail             # Sync Gmail emails to PKM systems
 ./pkm-sync calendar          # List and sync Google Calendar events
-./pkm-sync drive             # Export Google Drive documents to markdown
+./pkm-sync drive             # Sync Google Drive documents to PKM systems
 
 # Configuration management
 ./pkm-sync config init       # Create default configuration
@@ -106,7 +106,7 @@ This is a Go CLI application that provides universal Personal Knowledge Manageme
 ### Sources
 - ✅ **Gmail** - Fully implemented with multi-instance support, advanced filtering, thread grouping, and performance optimizations
 - ✅ **Google Calendar** - Fully implemented in `internal/sources/google/`
-- ✅ **Google Drive** - Fully implemented for document export
+- ✅ **Google Drive** - Fully implemented as a first-class source (`google_drive` type) syncing Docs/Sheets/Slides from folders and shared drives
 - 🔧 **Additional sources** (Slack, Jira) are planned but not yet implemented
 
 ### Targets
@@ -136,10 +136,11 @@ This is a Go CLI application that provides universal Personal Knowledge Manageme
   - Calendar-specific functionality
   - Example: `pkm-sync calendar --start 2025-01-01 --end 2025-01-31`
 
-- **`drive`** - Export Google Drive documents to markdown
-  - `drive fetch <URL>` - Fetch specific document by URL (supports txt, md, html, csv formats)
-  - Drive-specific functionality for document export
-  - Example: `pkm-sync drive fetch https://docs.google.com/document/d/...`
+- **`drive`** - Sync Google Drive documents (Docs, Sheets, Slides) to PKM systems
+  - Reads `google_drive` sources from config file (folder IDs, shared drives, workspace types)
+  - `drive fetch <URL>` - Fetch a single document by URL and write to stdout (unchanged)
+  - Example: `pkm-sync drive --source my_drive --target obsidian --since 7d`
+  - Example: `pkm-sync drive fetch "https://docs.google.com/document/d/abc123/edit" --format md`
 
 ### Utility Commands
 - **`setup`** - Verify authentication configuration

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -190,6 +190,55 @@ Gmail integration supports multiple instances (e.g., `gmail_work`, `gmail_person
 | `request_delay` | duration | `100ms` | Delay between API requests |
 | `max_requests` | integer | `100` | Maximum API requests |
 
+### Google Drive Source Settings (`sources.{name}.drive:`)
+
+Settings for `google_drive` type sources:
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `name` | string | **required** | Human-readable name for this source |
+| `description` | string | `""` | Optional description |
+| `folder_ids` | array | `[]` | Folder IDs to sync; empty = root only |
+| `recursive` | boolean | `true` | Recurse into subfolders |
+| `include_shared_with_me` | boolean | `false` | Include files shared with you |
+| `include_shared_drives` | boolean | `false` | Include files from shared drives |
+| `workspace_types` | array | `[]` (all) | Types to sync: `"document"`, `"spreadsheet"`, `"presentation"` |
+| `doc_export_format` | string | `"md"` | Export format for Docs: `md`, `txt`, `html` |
+| `sheet_export_format` | string | `"csv"` | Export format for Sheets: `csv`, `html` |
+| `slide_export_format` | string | `"txt"` | Export format for Slides: `txt`, `html` |
+| `query` | string | `""` | Extra Drive API query (appended with AND) |
+| `request_delay` | duration | `0` | Delay between API requests |
+| `max_requests` | integer | `0` | Max API requests per sync (0 = unlimited) |
+
+**Example `google_drive` source configuration:**
+
+```yaml
+sources:
+  my_drive:
+    enabled: true
+    type: google_drive
+    since: 30d
+    drive:
+      name: "My Drive Docs"
+      folder_ids:
+        - "1aBcDeFgHiJkLmNoPqRsTuVwXyZ"  # replace with real folder ID
+      recursive: true
+      workspace_types:
+        - document
+        - spreadsheet
+      doc_export_format: md
+      sheet_export_format: csv
+  shared_drive:
+    enabled: true
+    type: google_drive
+    drive:
+      name: "Team Shared Drive"
+      include_shared_with_me: true
+      include_shared_drives: true
+      workspace_types:
+        - document
+```
+
 ### Enhanced Source Configuration (`sources.{name}:`)
 
 Enhanced source settings support per-instance customization:
@@ -197,7 +246,7 @@ Enhanced source settings support per-instance customization:
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `enabled` | boolean | varies | Enable this source |
-| `type` | string | varies | Source type (google_calendar, gmail, slack, jira) |
+| `type` | string | varies | Source type (google_calendar, gmail, google_drive, slack, jira) |
 | `name` | string | `""` | Human-readable instance name |
 | `output_subdir` | string | `""` | Custom subdirectory for this source |
 | `output_target` | string | `""` | Override default target for this source |

--- a/cmd/drive_test.go
+++ b/cmd/drive_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"testing"
+
+	"pkm-sync/pkg/models"
+)
+
+func TestGetEnabledDriveSources_ExplicitList(t *testing.T) {
+	cfg := &models.Config{
+		Sync: models.SyncConfig{
+			EnabledSources: []string{"drive1", "drive2", "gmail_work"},
+		},
+		Sources: map[string]models.SourceConfig{
+			"drive1": {
+				Enabled: true,
+				Type:    "google_drive",
+			},
+			"drive2": {
+				Enabled: true,
+				Type:    "google_drive",
+			},
+			"gmail_work": {
+				Enabled: true,
+				Type:    "gmail",
+			},
+			"drive_disabled": {
+				Enabled: false,
+				Type:    "google_drive",
+			},
+		},
+	}
+
+	sources := getEnabledDriveSources(cfg)
+
+	if len(sources) != 2 {
+		t.Errorf("getEnabledDriveSources() returned %d sources, want 2", len(sources))
+	}
+
+	sourceSet := make(map[string]bool)
+	for _, s := range sources {
+		sourceSet[s] = true
+	}
+
+	if !sourceSet["drive1"] {
+		t.Error("expected drive1 to be included")
+	}
+
+	if !sourceSet["drive2"] {
+		t.Error("expected drive2 to be included")
+	}
+
+	if sourceSet["gmail_work"] {
+		t.Error("expected gmail_work to be excluded (wrong type)")
+	}
+}
+
+func TestGetEnabledDriveSources_Fallback(t *testing.T) {
+	// No explicit enabled_sources list → fall back to scanning all sources
+	cfg := &models.Config{
+		Sync: models.SyncConfig{
+			EnabledSources: []string{},
+		},
+		Sources: map[string]models.SourceConfig{
+			"my_drive": {
+				Enabled: true,
+				Type:    "google_drive",
+			},
+			"calendar": {
+				Enabled: true,
+				Type:    "google_calendar",
+			},
+			"drive_off": {
+				Enabled: false,
+				Type:    "google_drive",
+			},
+		},
+	}
+
+	sources := getEnabledDriveSources(cfg)
+
+	if len(sources) != 1 {
+		t.Errorf("getEnabledDriveSources() returned %d sources, want 1", len(sources))
+	}
+
+	if sources[0] != "my_drive" {
+		t.Errorf("getEnabledDriveSources() = %v, want [my_drive]", sources)
+	}
+}
+
+func TestGetEnabledDriveSources_Empty(t *testing.T) {
+	cfg := &models.Config{
+		Sync: models.SyncConfig{
+			EnabledSources: []string{},
+		},
+		Sources: map[string]models.SourceConfig{
+			"calendar": {
+				Enabled: true,
+				Type:    "google_calendar",
+			},
+		},
+	}
+
+	sources := getEnabledDriveSources(cfg)
+
+	if len(sources) != 0 {
+		t.Errorf("getEnabledDriveSources() returned %d sources, want 0", len(sources))
+	}
+}
+
+func TestGetEnabledDriveSources_DisabledInExplicitList(t *testing.T) {
+	cfg := &models.Config{
+		Sync: models.SyncConfig{
+			EnabledSources: []string{"drive1"},
+		},
+		Sources: map[string]models.SourceConfig{
+			"drive1": {
+				Enabled: false, // disabled
+				Type:    "google_drive",
+			},
+		},
+	}
+
+	sources := getEnabledDriveSources(cfg)
+
+	if len(sources) != 0 {
+		t.Errorf("getEnabledDriveSources() returned %d sources, want 0 (disabled source)", len(sources))
+	}
+}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -50,8 +50,15 @@ func createSourceWithConfig(sourceID string, sourceConfig models.SourceConfig, c
 		}
 
 		return source, nil
+	case "google_drive":
+		source := google.NewGoogleSourceWithConfig(sourceID, sourceConfig)
+		if err := source.Configure(nil, client); err != nil {
+			return nil, err
+		}
+
+		return source, nil
 	default:
-		return nil, fmt.Errorf("unknown source type '%s': supported types are 'google_calendar', 'gmail' (others like slack, jira are planned for future releases)", sourceConfig.Type)
+		return nil, fmt.Errorf("unknown source type '%s': supported types are 'google_calendar', 'gmail', 'google_drive' (others like slack, jira are planned for future releases)", sourceConfig.Type)
 	}
 }
 
@@ -158,6 +165,29 @@ func getEnabledGmailSources(cfg *models.Config) []string {
 
 	for srcName, sourceConfig := range cfg.Sources {
 		if sourceConfig.Enabled && sourceConfig.Type == "gmail" {
+			enabledSources = append(enabledSources, srcName)
+		}
+	}
+
+	return enabledSources
+}
+
+// getEnabledDriveSources returns enabled Google Drive source names from config.
+func getEnabledDriveSources(cfg *models.Config) []string {
+	var enabledSources []string
+
+	if len(cfg.Sync.EnabledSources) > 0 {
+		for _, srcName := range cfg.Sync.EnabledSources {
+			if sourceConfig, exists := cfg.Sources[srcName]; exists && sourceConfig.Enabled && sourceConfig.Type == "google_drive" {
+				enabledSources = append(enabledSources, srcName)
+			}
+		}
+
+		return enabledSources
+	}
+
+	for srcName, sourceConfig := range cfg.Sources {
+		if sourceConfig.Enabled && sourceConfig.Type == "google_drive" {
 			enabledSources = append(enabledSources, srcName)
 		}
 	}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -108,7 +108,7 @@ func runSyncCommand(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		if sourceConfig.Type != "gmail" && sourceConfig.Type != "google_calendar" {
+		if sourceConfig.Type != "gmail" && sourceConfig.Type != "google_calendar" && sourceConfig.Type != "google_drive" {
 			fmt.Printf("Warning: source '%s' has unsupported type '%s', skipping\n", srcName, sourceConfig.Type)
 
 			continue

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,6 +93,18 @@ func GetDefaultConfig() *models.Config {
 					DocFormats:        []string{},
 				},
 			},
+			"google_drive": {
+				Enabled: false,
+				Type:    "google_drive",
+				Drive: models.DriveSourceConfig{
+					Name:            "My Drive",
+					Description:     "Sync Google Docs, Sheets, and Slides from Google Drive",
+					FolderIDs:       []string{},
+					Recursive:       true,
+					WorkspaceTypes:  []string{},
+					DocExportFormat: "md",
+				},
+			},
 		},
 		Targets: map[string]models.TargetConfig{
 			"obsidian": {
@@ -279,6 +291,28 @@ func validateSourceConfig(_ string, config models.SourceConfig) error {
 	case "gmail":
 		if config.Gmail.Name == "" {
 			return fmt.Errorf("name is required for gmail sources")
+		}
+	case "google_drive":
+		if config.Drive.Name == "" {
+			return fmt.Errorf("name is required for google_drive sources")
+		}
+
+		validDocFormats := map[string]bool{"md": true, "txt": true, "html": true, "": true}
+		if !validDocFormats[config.Drive.DocExportFormat] {
+			return fmt.Errorf("invalid doc_export_format %q for google_drive (supported: md, txt, html)",
+				config.Drive.DocExportFormat)
+		}
+
+		validSheetFormats := map[string]bool{"csv": true, "html": true, "": true}
+		if !validSheetFormats[config.Drive.SheetExportFormat] {
+			return fmt.Errorf("invalid sheet_export_format %q for google_drive (supported: csv, html)",
+				config.Drive.SheetExportFormat)
+		}
+
+		validSlideFormats := map[string]bool{"txt": true, "html": true, "": true}
+		if !validSlideFormats[config.Drive.SlideExportFormat] {
+			return fmt.Errorf("invalid slide_export_format %q for google_drive (supported: txt, html)",
+				config.Drive.SlideExportFormat)
 		}
 	case "slack":
 		// Add slack-specific validations if needed

--- a/internal/sources/google/drive/service_test.go
+++ b/internal/sources/google/drive/service_test.go
@@ -1,0 +1,152 @@
+package drive
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestIsGoogleWorkspaceFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		mimeType string
+		want     bool
+	}{
+		{"google doc", MimeTypeGoogleDoc, true},
+		{"google sheet", MimeTypeGoogleSheet, true},
+		{"google slides", MimeTypeGooglePresentation, true},
+		{"pdf", "application/pdf", false},
+		{"plain text", "text/plain", false},
+		{"empty", "", false},
+		{"folder", "application/vnd.google-apps.folder", false},
+		{"jpeg", "image/jpeg", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsGoogleWorkspaceFile(tt.mimeType); got != tt.want {
+				t.Errorf("IsGoogleWorkspaceFile(%q) = %v, want %v", tt.mimeType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildQuery(t *testing.T) {
+	now := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		opts     ListFilesOptions
+		wantPart string // substring that must appear in result
+		notWant  string // substring that must NOT appear in result
+	}{
+		{
+			name:     "always includes trashed filter",
+			opts:     ListFilesOptions{},
+			wantPart: "trashed = false",
+		},
+		{
+			name:     "folder filter",
+			opts:     ListFilesOptions{FolderID: "abc123"},
+			wantPart: "'abc123' in parents",
+		},
+		{
+			name:    "no folder filter when empty",
+			opts:    ListFilesOptions{},
+			notWant: "in parents",
+		},
+		{
+			name:     "modified after filter",
+			opts:     ListFilesOptions{ModifiedAfter: now},
+			wantPart: "modifiedTime > '2025-06-01T12:00:00Z'",
+		},
+		{
+			name:    "no modified after when zero",
+			opts:    ListFilesOptions{},
+			notWant: "modifiedTime",
+		},
+		{
+			name:     "single mime type filter",
+			opts:     ListFilesOptions{MimeTypes: []string{MimeTypeGoogleDoc}},
+			wantPart: "mimeType = 'application/vnd.google-apps.document'",
+		},
+		{
+			name: "multiple mime types use OR",
+			opts: ListFilesOptions{MimeTypes: []string{
+				MimeTypeGoogleDoc,
+				MimeTypeGoogleSheet,
+			}},
+			wantPart: "mimeType = 'application/vnd.google-apps.document' or mimeType = 'application/vnd.google-apps.spreadsheet'",
+		},
+		{
+			name:     "shared with me filter",
+			opts:     ListFilesOptions{IncludeSharedWithMe: true},
+			wantPart: "sharedWithMe = true",
+		},
+		{
+			name:     "extra query appended",
+			opts:     ListFilesOptions{ExtraQuery: "name contains 'report'"},
+			wantPart: "name contains 'report'",
+		},
+		{
+			name:     "extra query not doubled with AND when there are other filters",
+			opts:     ListFilesOptions{FolderID: "abc", ExtraQuery: "name contains 'x'"},
+			wantPart: "and name contains 'x'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildQuery(tt.opts)
+
+			if tt.wantPart != "" {
+				if !strings.Contains(got, tt.wantPart) {
+					t.Errorf("buildQuery() = %q, want it to contain %q", got, tt.wantPart)
+				}
+			}
+
+			if tt.notWant != "" {
+				if strings.Contains(got, tt.notWant) {
+					t.Errorf("buildQuery() = %q, want it NOT to contain %q", got, tt.notWant)
+				}
+			}
+		})
+	}
+}
+
+func TestGetExportMimeType(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileMime string
+		format   string
+		wantMime string
+		wantErr  bool
+	}{
+		{"doc to txt", MimeTypeGoogleDoc, "txt", MimeTypePlainText, false},
+		{"doc to md", MimeTypeGoogleDoc, "md", MimeTypeHTML, false},
+		{"doc to html", MimeTypeGoogleDoc, "html", MimeTypeHTML, false},
+		{"doc to csv invalid", MimeTypeGoogleDoc, "csv", "", true},
+		{"sheet to csv", MimeTypeGoogleSheet, "csv", MimeTypeCSV, false},
+		{"sheet to html", MimeTypeGoogleSheet, "html", MimeTypeHTML, false},
+		{"sheet to md invalid", MimeTypeGoogleSheet, "md", "", true},
+		{"slides to txt", MimeTypeGooglePresentation, "txt", MimeTypePlainText, false},
+		{"slides to html", MimeTypeGooglePresentation, "html", MimeTypeHTML, false},
+		{"slides to csv invalid", MimeTypeGooglePresentation, "csv", "", true},
+		{"unsupported type", "application/pdf", "txt", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetExportMimeType(tt.fileMime, tt.format)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetExportMimeType(%q, %q) error = %v, wantErr %v", tt.fileMime, tt.format, err, tt.wantErr)
+
+				return
+			}
+
+			if !tt.wantErr && got != tt.wantMime {
+				t.Errorf("GetExportMimeType(%q, %q) = %q, want %q", tt.fileMime, tt.format, got, tt.wantMime)
+			}
+		})
+	}
+}

--- a/internal/sources/google/drive/types.go
+++ b/internal/sources/google/drive/types.go
@@ -1,0 +1,38 @@
+package drive
+
+import "time"
+
+// ListFilesOptions controls how files are listed from Google Drive.
+type ListFilesOptions struct {
+	// FolderID limits listing to a specific folder; empty means no folder filter.
+	FolderID string
+	// ModifiedAfter filters files to those modified after this time (zero = no filter).
+	ModifiedAfter time.Time
+	// MimeTypes restricts results to these MIME types (empty = no filter).
+	MimeTypes []string
+	// IncludeSharedWithMe adds "sharedWithMe = true" to the query.
+	IncludeSharedWithMe bool
+	// IncludeSharedDrives includes results from shared drives.
+	IncludeSharedDrives bool
+	// PageSize is the number of results per page (default 100, max 1000).
+	PageSize int
+	// MaxResults caps total results; 0 means unlimited.
+	MaxResults int
+	// ExtraQuery is appended with AND to the generated query.
+	ExtraQuery string
+}
+
+// DriveFileInfo holds metadata for a Google Drive file.
+type DriveFileInfo struct {
+	ID           string
+	Name         string
+	MimeType     string
+	WebViewLink  string
+	ModifiedTime time.Time
+	CreatedTime  time.Time
+	Owners       []string
+	Size         int64
+	Parents      []string
+	Description  string
+	Starred      bool
+}

--- a/internal/sources/google/source.go
+++ b/internal/sources/google/source.go
@@ -17,6 +17,7 @@ const (
 	SourceTypeGoogle   = "google"
 	SourceTypeGmail    = "gmail"
 	SourceTypeCalendar = "google_calendar"
+	SourceTypeDrive    = "google_drive"
 )
 
 type GoogleSource struct {
@@ -44,11 +45,14 @@ func (g *GoogleSource) Name() string {
 		return g.sourceID
 	}
 
-	if g.config.Type == SourceTypeGmail {
+	switch g.config.Type {
+	case SourceTypeGmail:
 		return SourceTypeGmail
+	case SourceTypeDrive:
+		return SourceTypeDrive
+	default:
+		return SourceTypeCalendar
 	}
-
-	return SourceTypeCalendar
 }
 
 func (g *GoogleSource) Configure(config map[string]interface{}, client *http.Client) error {
@@ -64,12 +68,15 @@ func (g *GoogleSource) Configure(config map[string]interface{}, client *http.Cli
 	g.httpClient = client
 
 	// Initialize services based on source type
-	if g.config.Type == SourceTypeGmail {
+	switch g.config.Type {
+	case SourceTypeGmail:
 		return g.initializeGmailService(client)
+	case SourceTypeDrive:
+		return g.initializeDriveOnlyService(client)
+	default:
+		// Default to calendar and drive services
+		return g.initializeCalendarAndDriveServices(client, config)
 	}
-
-	// Default to calendar and drive services
-	return g.initializeCalendarAndDriveServices(client, config)
 }
 
 // initializeGmailService initializes the Gmail service for Gmail sources.
@@ -138,12 +145,14 @@ func (g *GoogleSource) configureCalendarService(config map[string]interface{}) {
 }
 
 func (g *GoogleSource) Fetch(since time.Time, limit int) ([]models.FullItem, error) {
-	if g.config.Type == SourceTypeGmail {
+	switch g.config.Type {
+	case SourceTypeGmail:
 		return g.fetchGmail(since, limit)
+	case SourceTypeDrive:
+		return g.fetchDrive(since, limit)
+	default:
+		return g.fetchCalendar(since, limit)
 	}
-
-	// Default: Handle Google Calendar sources
-	return g.fetchCalendar(since, limit)
 }
 
 func (g *GoogleSource) fetchGmail(since time.Time, limit int) ([]models.FullItem, error) {
@@ -226,6 +235,204 @@ func (g *GoogleSource) fetchCalendar(since time.Time, limit int) ([]models.FullI
 
 func (g *GoogleSource) SupportsRealtime() bool {
 	return false // Future: implement webhooks
+}
+
+// initializeDriveOnlyService initializes only the Drive service for Drive sources.
+func (g *GoogleSource) initializeDriveOnlyService(client *http.Client) error {
+	var err error
+
+	g.driveService, err = drive.NewService(client)
+	if err != nil {
+		return fmt.Errorf("failed to initialize Drive service: %w", err)
+	}
+
+	return nil
+}
+
+// fetchDrive fetches Google Drive documents as items.
+func (g *GoogleSource) fetchDrive(since time.Time, limit int) ([]models.FullItem, error) {
+	if g.driveService == nil {
+		return nil, fmt.Errorf("drive service not initialized")
+	}
+
+	cfg := g.config.Drive
+
+	// Build MIME type filter from configured workspace types
+	var mimeTypes []string
+
+	if len(cfg.WorkspaceTypes) > 0 {
+		for _, wt := range cfg.WorkspaceTypes {
+			switch wt {
+			case "document":
+				mimeTypes = append(mimeTypes, drive.MimeTypeGoogleDoc)
+			case "spreadsheet":
+				mimeTypes = append(mimeTypes, drive.MimeTypeGoogleSheet)
+			case "presentation":
+				mimeTypes = append(mimeTypes, drive.MimeTypeGooglePresentation)
+			}
+		}
+	} else {
+		// Default: all workspace types
+		mimeTypes = []string{
+			drive.MimeTypeGoogleDoc,
+			drive.MimeTypeGoogleSheet,
+			drive.MimeTypeGooglePresentation,
+		}
+	}
+
+	listOpts := drive.ListFilesOptions{
+		MimeTypes:           mimeTypes,
+		ModifiedAfter:       since,
+		ExtraQuery:          cfg.Query,
+		IncludeSharedDrives: cfg.IncludeSharedDrives,
+	}
+
+	if limit > 0 {
+		listOpts.MaxResults = limit
+	}
+
+	// Collect files, deduplicating across folders
+	seen := make(map[string]bool)
+
+	var allFiles []*drive.DriveFileInfo
+
+	folderIDs := cfg.FolderIDs
+	if len(folderIDs) == 0 {
+		folderIDs = []string{"root"}
+	}
+
+	for _, folderID := range folderIDs {
+		files, err := g.driveService.ListFilesInFolder(folderID, since, cfg.Recursive, listOpts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list files in folder %s: %w", folderID, err)
+		}
+
+		for _, f := range files {
+			if !seen[f.ID] {
+				seen[f.ID] = true
+				allFiles = append(allFiles, f)
+			}
+		}
+	}
+
+	if cfg.IncludeSharedWithMe {
+		sharedFiles, err := g.driveService.ListSharedWithMe(since, listOpts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list shared-with-me files: %w", err)
+		}
+
+		for _, f := range sharedFiles {
+			if !seen[f.ID] {
+				seen[f.ID] = true
+				allFiles = append(allFiles, f)
+			}
+		}
+	}
+
+	// Apply limit after deduplication
+	if limit > 0 && len(allFiles) > limit {
+		allFiles = allFiles[:limit]
+	}
+
+	items := make([]models.FullItem, 0, len(allFiles))
+
+	for _, f := range allFiles {
+		item, err := g.convertDriveFile(f, cfg)
+		if err != nil {
+			fmt.Printf("Warning: failed to convert drive file '%s': %v\n", f.Name, err)
+
+			continue
+		}
+
+		items = append(items, item)
+	}
+
+	return items, nil
+}
+
+// convertDriveFile converts a DriveFileInfo to a models.FullItem.
+func (g *GoogleSource) convertDriveFile(
+	file *drive.DriveFileInfo,
+	cfg models.DriveSourceConfig,
+) (models.FullItem, error) {
+	// Determine export format based on file type
+	var format string
+
+	switch file.MimeType {
+	case drive.MimeTypeGoogleDoc:
+		format = cfg.DocExportFormat
+		if format == "" {
+			format = drive.FormatMD
+		}
+	case drive.MimeTypeGoogleSheet:
+		format = cfg.SheetExportFormat
+		if format == "" {
+			format = drive.FormatCSV
+		}
+	case drive.MimeTypeGooglePresentation:
+		format = cfg.SlideExportFormat
+		if format == "" {
+			format = drive.FormatTXT
+		}
+	default:
+		return nil, fmt.Errorf("unsupported MIME type for export: %s", file.MimeType)
+	}
+
+	exportMimeType, err := drive.GetExportMimeType(file.MimeType, format)
+	if err != nil {
+		return nil, err
+	}
+
+	convertToMarkdown := (format == drive.FormatMD)
+
+	content, err := g.driveService.ExportAsString(file.ID, exportMimeType, convertToMarkdown)
+	if err != nil {
+		return nil, fmt.Errorf("failed to export file '%s': %w", file.Name, err)
+	}
+
+	// Map MIME type to item type
+	var itemType string
+
+	switch file.MimeType {
+	case drive.MimeTypeGoogleDoc:
+		itemType = "document"
+	case drive.MimeTypeGoogleSheet:
+		itemType = "spreadsheet"
+	case drive.MimeTypeGooglePresentation:
+		itemType = "presentation"
+	}
+
+	metadata := map[string]interface{}{
+		"mime_type":     file.MimeType,
+		"web_view_link": file.WebViewLink,
+		"owners":        file.Owners,
+		"starred":       file.Starred,
+	}
+
+	var links []models.Link
+
+	if file.WebViewLink != "" {
+		links = append(links, models.Link{
+			URL:   file.WebViewLink,
+			Title: "View in Drive",
+			Type:  "document",
+		})
+	}
+
+	item := &models.BasicItem{
+		ID:         file.ID,
+		Title:      file.Name,
+		Content:    content,
+		SourceType: SourceTypeDrive,
+		ItemType:   itemType,
+		CreatedAt:  file.CreatedTime,
+		UpdatedAt:  file.ModifiedTime,
+		Tags:       []string{},
+		Metadata:   metadata,
+		Links:      links,
+	}
+
+	return item, nil
 }
 
 // Ensure GoogleSource implements Source interface.

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -83,11 +83,40 @@ type SourceConfig struct {
 	Priority     int           `json:"priority,omitempty"      yaml:"priority,omitempty"`
 
 	// Source-specific configurations
-	// Source-specific configurations
 	Google GoogleSourceConfig `json:"google,omitempty" yaml:"google,omitempty"`
 	Slack  SlackSourceConfig  `json:"slack,omitempty"  yaml:"slack,omitempty"`
 	Gmail  GmailSourceConfig  `json:"gmail,omitempty"  yaml:"gmail,omitempty"`
 	Jira   JiraSourceConfig   `json:"jira,omitempty"   yaml:"jira,omitempty"`
+	Drive  DriveSourceConfig  `json:"drive,omitempty"  yaml:"drive,omitempty"`
+}
+
+// DriveSourceConfig defines configuration for a Google Drive source.
+type DriveSourceConfig struct {
+	Name        string `json:"name"        yaml:"name"`
+	Description string `json:"description" yaml:"description"`
+
+	// Folders to sync; empty = root only
+	FolderIDs []string `json:"folder_ids" yaml:"folder_ids"`
+	// Recurse into subfolders (default: true)
+	Recursive bool `json:"recursive" yaml:"recursive"`
+
+	IncludeSharedWithMe bool `json:"include_shared_with_me" yaml:"include_shared_with_me"`
+	IncludeSharedDrives bool `json:"include_shared_drives"  yaml:"include_shared_drives"`
+
+	// Which workspace types to export (empty = all): "document", "spreadsheet", "presentation"
+	WorkspaceTypes []string `json:"workspace_types" yaml:"workspace_types"`
+
+	// Export format preferences
+	DocExportFormat   string `json:"doc_export_format"   yaml:"doc_export_format"`   // "md" (default), "txt", "html"
+	SheetExportFormat string `json:"sheet_export_format" yaml:"sheet_export_format"` // "csv" (default), "html"
+	SlideExportFormat string `json:"slide_export_format" yaml:"slide_export_format"` // "txt" (default), "html"
+
+	// Custom Drive API query (appended with AND to the generated query)
+	Query string `json:"query" yaml:"query"`
+
+	// Rate limiting
+	RequestDelay time.Duration `json:"request_delay" yaml:"request_delay"`
+	MaxRequests  int           `json:"max_requests"  yaml:"max_requests"`
 }
 
 type GoogleSourceConfig struct {


### PR DESCRIPTION
## Summary

- Adds `google_drive` as a proper `interfaces.Source` so Drive documents participate in the full sync pipeline alongside Gmail and Calendar
- Rewrites `cmd/export.go` (the `drive` command) as a source-aware sync command following the `gmail` command pattern; `drive fetch <URL>` subcommand is preserved unchanged
- Only Google Workspace files (Docs, Sheets, Slides) are synced — native binary files are skipped

## What's new

**Config model** (`pkg/models/config.go`): `DriveSourceConfig` struct with folder IDs, recursive traversal, shared-drive options, workspace type filtering (`document`/`spreadsheet`/`presentation`), per-type export formats, and custom query support.

**Drive service extensions** (`internal/sources/google/drive/`):
- `types.go` — `ListFilesOptions` and `DriveFileInfo` types
- `service.go` — `ListFiles` (paginated), `ListFilesInFolder` (recursive), `ListSharedWithMe`, `ExportAsString` (with optional HTML→Markdown), `IsGoogleWorkspaceFile`, `buildQuery`

**GoogleSource dispatch** (`internal/sources/google/source.go`): `SourceTypeDrive = "google_drive"` constant; updated `Name`/`Configure`/`Fetch` switches; new `fetchDrive` (multi-folder dedup + limit) and `convertDriveFile` (exports content, builds `BasicItem`).

**Registration touchpoints**: `google_drive` validation in `internal/config/config.go`; `google_drive` case in `createSourceWithConfig`; type guard in `cmd/sync.go`; disabled example source in `GetDefaultConfig`.

## Test plan

- [ ] `go test ./...` — all existing and new tests pass
- [ ] `make ci` — lint + test + build pass
- [ ] Manual: `pkm-sync drive --dry-run --since 30d` with a config containing a `google_drive` source
- [ ] Manual: `pkm-sync sync --dry-run` with `google_drive` in `enabled_sources`
- [ ] Manual: `pkm-sync drive fetch <URL>` still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)