### PR TITLE
feat(drive): add comment export support and fix URL fragment stripping

### DIFF
--- a/cmd/drive_fetch.go
+++ b/cmd/drive_fetch.go
@@ -94,6 +94,11 @@ func runDriveFetchCommand(cmd *cobra.Command, args []string) error {
 		_ = content.Close()
 	}()
 
+	// Warn if --comments used with non-markdown format
+	if fetchComments && fetchFormat != "md" {
+		fmt.Fprintln(os.Stderr, "Warning: --comments is only supported with --format md, ignoring")
+	}
+
 	// Non-markdown formats: write content directly to stdout
 	if fetchFormat != "md" {
 		_, err = io.Copy(os.Stdout, content)

--- a/cmd/drive_fetch.go
+++ b/cmd/drive_fetch.go
@@ -13,7 +13,8 @@ import (
 )
 
 var (
-	fetchFormat string
+	fetchFormat   string
+	fetchComments bool
 )
 
 var driveFetchCmd = &cobra.Command{
@@ -34,9 +35,11 @@ Output formats:
   - html : HTML
   - csv  : CSV (for spreadsheets only)
 
+Use --comments to append document comments as markdown footnotes (md format only).
+
 Examples:
   pkm-sync drive fetch "https://docs.google.com/document/d/abc123/edit"
-  pkm-sync drive fetch "https://docs.google.com/document/d/abc123/edit" --format md
+  pkm-sync drive fetch "https://docs.google.com/document/d/abc123/edit" --format md --comments
   pkm-sync drive fetch "https://docs.google.com/spreadsheets/d/xyz789/edit" --format csv`,
 	Args: cobra.ExactArgs(1),
 	RunE: runDriveFetchCommand,
@@ -45,6 +48,7 @@ Examples:
 func init() {
 	driveCmd.AddCommand(driveFetchCmd)
 	driveFetchCmd.Flags().StringVar(&fetchFormat, "format", "txt", "Output format (txt, md, html, csv)")
+	driveFetchCmd.Flags().BoolVar(&fetchComments, "comments", false, "Append document comments as markdown footnotes (md format only)")
 }
 
 func runDriveFetchCommand(cmd *cobra.Command, args []string) error {
@@ -90,25 +94,48 @@ func runDriveFetchCommand(cmd *cobra.Command, args []string) error {
 		_ = content.Close()
 	}()
 
-	// If format is markdown, convert HTML to markdown
-	if fetchFormat == "md" {
-		htmlBytes, err := io.ReadAll(content)
-		if err != nil {
-			return fmt.Errorf("failed to read HTML content: %w", err)
-		}
-
-		markdown, err := mdconverter.ConvertString(string(htmlBytes))
-		if err != nil {
-			return fmt.Errorf("failed to convert HTML to markdown: %w", err)
-		}
-
-		_, err = fmt.Fprint(os.Stdout, markdown)
+	// Non-markdown formats: write content directly to stdout
+	if fetchFormat != "md" {
+		_, err = io.Copy(os.Stdout, content)
 
 		return err
 	}
 
-	// Otherwise, write content directly to stdout
-	_, err = io.Copy(os.Stdout, content)
+	// Markdown: convert HTML to markdown
+	htmlBytes, err := io.ReadAll(content)
+	if err != nil {
+		return fmt.Errorf("failed to read HTML content: %w", err)
+	}
+
+	markdown, err := mdconverter.ConvertString(string(htmlBytes))
+	if err != nil {
+		return fmt.Errorf("failed to convert HTML to markdown: %w", err)
+	}
+
+	if fetchComments {
+		markdown, err = appendComments(driveService, fileID, markdown)
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err = fmt.Fprint(os.Stdout, markdown)
 
 	return err
+}
+
+func appendComments(driveService *drive.Service, fileID, markdown string) (string, error) {
+	comments, err := driveService.GetComments(fileID)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch comments: %w", err)
+	}
+
+	if len(comments) == 0 {
+		return markdown, nil
+	}
+
+	markdown = drive.InsertCommentMarkers(markdown, comments)
+	markdown += "\n\n" + drive.FormatCommentsAsFootnotes(comments)
+
+	return markdown, nil
 }

--- a/internal/sources/google/drive/comments.go
+++ b/internal/sources/google/drive/comments.go
@@ -1,0 +1,85 @@
+package drive
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FormatCommentsAsFootnotes formats comments as markdown footnote definitions.
+func FormatCommentsAsFootnotes(comments []CommentData) string {
+	if len(comments) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+
+	sb.WriteString("---\n\n## Comments\n\n")
+
+	for _, c := range comments {
+		sb.WriteString(fmt.Sprintf("[^comment-%d]: ", c.CommentNumber))
+
+		// Author and timestamp
+		author := c.Author
+		if author == "" {
+			author = "Unknown"
+		}
+
+		sb.WriteString(fmt.Sprintf("**%s**", author))
+
+		if c.CreatedTime != "" {
+			sb.WriteString(fmt.Sprintf(" (%s)", c.CreatedTime))
+		}
+
+		sb.WriteString(" — ")
+
+		if c.Resolved {
+			sb.WriteString("*Resolved*")
+		} else {
+			sb.WriteString("*Open*")
+		}
+
+		sb.WriteString("  \n")
+
+		if c.QuotedText != "" {
+			sb.WriteString(fmt.Sprintf("    > %s  \n", c.QuotedText))
+		}
+
+		if c.Content != "" {
+			sb.WriteString("    " + c.Content + "  \n")
+		}
+
+		for _, r := range c.Replies {
+			rAuthor := r.Author
+			if rAuthor == "" {
+				rAuthor = "Unknown"
+			}
+
+			sb.WriteString(fmt.Sprintf("    - **%s**", rAuthor))
+
+			if r.CreatedTime != "" {
+				sb.WriteString(fmt.Sprintf(" (%s)", r.CreatedTime))
+			}
+
+			sb.WriteString(": " + r.Content + "  \n")
+		}
+
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+// InsertCommentMarkers inserts footnote reference markers into content at the
+// first occurrence of each comment's quoted text.
+func InsertCommentMarkers(content string, comments []CommentData) string {
+	for _, c := range comments {
+		if c.QuotedText == "" {
+			continue
+		}
+
+		marker := fmt.Sprintf("[^comment-%d]", c.CommentNumber)
+		content = strings.Replace(content, c.QuotedText, c.QuotedText+marker, 1)
+	}
+
+	return content
+}

--- a/internal/sources/google/drive/comments.go
+++ b/internal/sources/google/drive/comments.go
@@ -2,8 +2,21 @@ package drive
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
+
+// escapeMarkdown escapes markdown special characters in text.
+func escapeMarkdown(text string) string {
+	replacer := strings.NewReplacer(
+		"*", "\\*",
+		"_", "\\_",
+		"[", "\\[",
+		"]", "\\]",
+	)
+
+	return replacer.Replace(text)
+}
 
 // FormatCommentsAsFootnotes formats comments as markdown footnote definitions.
 func FormatCommentsAsFootnotes(comments []CommentData) string {
@@ -24,7 +37,7 @@ func FormatCommentsAsFootnotes(comments []CommentData) string {
 			author = "Unknown"
 		}
 
-		sb.WriteString(fmt.Sprintf("**%s**", author))
+		sb.WriteString(fmt.Sprintf("**%s**", escapeMarkdown(author)))
 
 		if c.CreatedTime != "" {
 			sb.WriteString(fmt.Sprintf(" (%s)", c.CreatedTime))
@@ -54,7 +67,7 @@ func FormatCommentsAsFootnotes(comments []CommentData) string {
 				rAuthor = "Unknown"
 			}
 
-			sb.WriteString(fmt.Sprintf("    - **%s**", rAuthor))
+			sb.WriteString(fmt.Sprintf("    - **%s**", escapeMarkdown(rAuthor)))
 
 			if r.CreatedTime != "" {
 				sb.WriteString(fmt.Sprintf(" (%s)", r.CreatedTime))
@@ -72,13 +85,41 @@ func FormatCommentsAsFootnotes(comments []CommentData) string {
 // InsertCommentMarkers inserts footnote reference markers into content at the
 // first occurrence of each comment's quoted text.
 func InsertCommentMarkers(content string, comments []CommentData) string {
+	// Find all match positions in original content
+	type insertion struct {
+		pos    int
+		text   string
+		marker string
+	}
+
+	var insertions []insertion
+
 	for _, c := range comments {
 		if c.QuotedText == "" {
 			continue
 		}
 
+		pos := strings.Index(content, c.QuotedText)
+		if pos == -1 {
+			continue
+		}
+
 		marker := fmt.Sprintf("[^comment-%d]", c.CommentNumber)
-		content = strings.Replace(content, c.QuotedText, c.QuotedText+marker, 1)
+		insertions = append(insertions, insertion{
+			pos:    pos + len(c.QuotedText),
+			text:   c.QuotedText,
+			marker: marker,
+		})
+	}
+
+	// Sort by position descending (apply from end to start)
+	sort.Slice(insertions, func(i, j int) bool {
+		return insertions[i].pos > insertions[j].pos
+	})
+
+	// Apply insertions from end to start
+	for _, ins := range insertions {
+		content = content[:ins.pos] + ins.marker + content[ins.pos:]
 	}
 
 	return content

--- a/internal/sources/google/drive/comments_test.go
+++ b/internal/sources/google/drive/comments_test.go
@@ -80,6 +80,15 @@ func TestFormatCommentsAsFootnotes(t *testing.T) {
 			}},
 			want: []string{"**Unknown**"},
 		},
+		{
+			name: "author name with markdown characters",
+			comments: []CommentData{{
+				CommentNumber: 1,
+				Author:        "Alice_[Bot]*",
+				Content:       "Test comment",
+			}},
+			want: []string{`**Alice\_\[Bot\]\***`},
+		},
 	}
 
 	for _, tt := range tests {
@@ -158,6 +167,15 @@ func TestInsertCommentMarkers(t *testing.T) {
 				QuotedText:    "missing text",
 			}},
 			want: "Hello world",
+		},
+		{
+			name:    "overlapping quoted text",
+			content: "The quick brown fox jumps over the lazy dog.",
+			comments: []CommentData{
+				{CommentNumber: 1, QuotedText: "quick brown"},
+				{CommentNumber: 2, QuotedText: "quick brown fox"},
+			},
+			want: "The quick brown[^comment-1] fox[^comment-2] jumps over the lazy dog.",
 		},
 	}
 

--- a/internal/sources/google/drive/comments_test.go
+++ b/internal/sources/google/drive/comments_test.go
@@ -1,0 +1,229 @@
+package drive
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatCommentsAsFootnotes(t *testing.T) {
+	tests := []struct {
+		name     string
+		comments []CommentData
+		want     []string // substrings that must appear
+		notWant  []string // substrings that must NOT appear
+	}{
+		{
+			name:     "empty",
+			comments: nil,
+			want:     nil,
+			notWant:  []string{"## Comments"},
+		},
+		{
+			name: "single open comment",
+			comments: []CommentData{{
+				CommentNumber: 1,
+				Author:        "Alice",
+				Content:       "Needs revision",
+				CreatedTime:   "2025-06-01 10:00",
+				Resolved:      false,
+			}},
+			want: []string{
+				"[^comment-1]:",
+				"**Alice**",
+				"(2025-06-01 10:00)",
+				"*Open*",
+				"Needs revision",
+			},
+		},
+		{
+			name: "resolved comment",
+			comments: []CommentData{{
+				CommentNumber: 1,
+				Author:        "Bob",
+				Content:       "Fixed",
+				Resolved:      true,
+			}},
+			want:    []string{"*Resolved*"},
+			notWant: []string{"*Open*"},
+		},
+		{
+			name: "comment with quoted text",
+			comments: []CommentData{{
+				CommentNumber: 1,
+				Author:        "Carol",
+				Content:       "Typo here",
+				QuotedText:    "the quick brown fox",
+			}},
+			want: []string{"> the quick brown fox"},
+		},
+		{
+			name: "comment with replies",
+			comments: []CommentData{{
+				CommentNumber: 1,
+				Author:        "Dave",
+				Content:       "Question",
+				Replies: []ReplyData{
+					{Author: "Eve", Content: "Answer", CreatedTime: "2025-06-02 14:00"},
+				},
+			}},
+			want: []string{
+				"**Eve**",
+				"(2025-06-02 14:00)",
+				": Answer",
+			},
+		},
+		{
+			name: "unknown author fallback",
+			comments: []CommentData{{
+				CommentNumber: 1,
+				Content:       "Anonymous comment",
+			}},
+			want: []string{"**Unknown**"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatCommentsAsFootnotes(tt.comments)
+
+			for _, w := range tt.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("FormatCommentsAsFootnotes() missing %q in:\n%s", w, got)
+				}
+			}
+
+			for _, nw := range tt.notWant {
+				if strings.Contains(got, nw) {
+					t.Errorf("FormatCommentsAsFootnotes() should not contain %q in:\n%s", nw, got)
+				}
+			}
+		})
+	}
+}
+
+func TestInsertCommentMarkers(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		comments []CommentData
+		want     string
+	}{
+		{
+			name:     "no comments",
+			content:  "Hello world",
+			comments: nil,
+			want:     "Hello world",
+		},
+		{
+			name:    "inserts marker after quoted text",
+			content: "The quick brown fox jumps over the lazy dog.",
+			comments: []CommentData{{
+				CommentNumber: 1,
+				QuotedText:    "quick brown fox",
+			}},
+			want: "The quick brown fox[^comment-1] jumps over the lazy dog.",
+		},
+		{
+			name:    "skips comment without quoted text",
+			content: "Hello world",
+			comments: []CommentData{{
+				CommentNumber: 1,
+				QuotedText:    "",
+			}},
+			want: "Hello world",
+		},
+		{
+			name:    "only replaces first occurrence",
+			content: "foo bar foo bar",
+			comments: []CommentData{{
+				CommentNumber: 1,
+				QuotedText:    "foo",
+			}},
+			want: "foo[^comment-1] bar foo bar",
+		},
+		{
+			name:    "multiple comments",
+			content: "alpha beta gamma",
+			comments: []CommentData{
+				{CommentNumber: 1, QuotedText: "alpha"},
+				{CommentNumber: 2, QuotedText: "gamma"},
+			},
+			want: "alpha[^comment-1] beta gamma[^comment-2]",
+		},
+		{
+			name:    "quoted text not found in content",
+			content: "Hello world",
+			comments: []CommentData{{
+				CommentNumber: 1,
+				QuotedText:    "missing text",
+			}},
+			want: "Hello world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := InsertCommentMarkers(tt.content, tt.comments)
+			if got != tt.want {
+				t.Errorf("InsertCommentMarkers() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractFileID_FragmentStripping(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "docs URL with fragment",
+			url:  "https://docs.google.com/document/d/abc123/edit#heading=h.xyz",
+			want: "abc123",
+		},
+		{
+			name: "docs URL without fragment",
+			url:  "https://docs.google.com/document/d/abc123/edit",
+			want: "abc123",
+		},
+		{
+			name: "docs URL with query and fragment",
+			url:  "https://docs.google.com/document/d/abc123/edit?usp=sharing#heading=h.xyz",
+			want: "abc123",
+		},
+		{
+			name: "drive URL with fragment",
+			url:  "https://drive.google.com/file/d/def456/view#something",
+			want: "def456",
+		},
+		{
+			name: "drive URL without fragment",
+			url:  "https://drive.google.com/file/d/def456/view",
+			want: "def456",
+		},
+		{
+			name: "open URL with fragment",
+			url:  "https://drive.google.com/open?id=ghi789#section",
+			want: "ghi789",
+		},
+		{
+			name: "open URL without fragment",
+			url:  "https://drive.google.com/open?id=ghi789",
+			want: "ghi789",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExtractFileID(tt.url)
+			if err != nil {
+				t.Fatalf("ExtractFileID(%q) error: %v", tt.url, err)
+			}
+
+			if got != tt.want {
+				t.Errorf("ExtractFileID(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sources/google/drive/service.go
+++ b/internal/sources/google/drive/service.go
@@ -147,6 +147,10 @@ func extractFileIDFromDocsURL(url string) string {
 			if idx := strings.Index(fileID, "?"); idx != -1 {
 				fileID = fileID[:idx]
 			}
+			// Remove any fragments
+			if idx := strings.Index(fileID, "#"); idx != -1 {
+				fileID = fileID[:idx]
+			}
 
 			return fileID
 		}
@@ -164,6 +168,10 @@ func extractFileIDFromDriveURL(url string) string {
 			fileID := parts[i+1]
 			// Remove any query parameters
 			if idx := strings.Index(fileID, "?"); idx != -1 {
+				fileID = fileID[:idx]
+			}
+			// Remove any fragments
+			if idx := strings.Index(fileID, "#"); idx != -1 {
 				fileID = fileID[:idx]
 			}
 
@@ -219,6 +227,10 @@ func extractFileIDFromOpenURL(url string) string {
 	fileID := parts[1]
 	// Remove any trailing parameters
 	if idx := strings.Index(fileID, "&"); idx != -1 {
+		fileID = fileID[:idx]
+	}
+	// Remove any fragments
+	if idx := strings.Index(fileID, "#"); idx != -1 {
 		fileID = fileID[:idx]
 	}
 
@@ -647,4 +659,65 @@ func convertFileInfo(f *drive.File) *DriveFileInfo {
 	}
 
 	return info
+}
+
+// GetComments retrieves all comments for a Google Drive file.
+func (s *Service) GetComments(fileID string) ([]CommentData, error) {
+	const fields = "comments(id,content,author(displayName),createdTime,resolved,quotedFileContent," +
+		"replies(content,author(displayName),createdTime))"
+
+	commentList, err := s.client.Comments.List(fileID).Fields(fields).Do()
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve comments: %w", err)
+	}
+
+	comments := make([]CommentData, 0, len(commentList.Comments))
+
+	for i, c := range commentList.Comments {
+		comment := CommentData{
+			ID:            c.Id,
+			Content:       c.Content,
+			Resolved:      c.Resolved,
+			CommentNumber: i + 1,
+		}
+
+		if c.Author != nil {
+			comment.Author = c.Author.DisplayName
+		}
+
+		if c.QuotedFileContent != nil {
+			comment.QuotedText = c.QuotedFileContent.Value
+		}
+
+		if c.CreatedTime != "" {
+			if t, err := time.Parse(time.RFC3339, c.CreatedTime); err == nil {
+				comment.CreatedTime = t.Format("2006-01-02 15:04")
+			}
+		}
+
+		if len(c.Replies) > 0 {
+			comment.Replies = make([]ReplyData, 0, len(c.Replies))
+			for _, r := range c.Replies {
+				reply := ReplyData{
+					Content: r.Content,
+				}
+
+				if r.Author != nil {
+					reply.Author = r.Author.DisplayName
+				}
+
+				if r.CreatedTime != "" {
+					if t, err := time.Parse(time.RFC3339, r.CreatedTime); err == nil {
+						reply.CreatedTime = t.Format("2006-01-02 15:04")
+					}
+				}
+
+				comment.Replies = append(comment.Replies, reply)
+			}
+		}
+
+		comments = append(comments, comment)
+	}
+
+	return comments, nil
 }

--- a/internal/sources/google/drive/service.go
+++ b/internal/sources/google/drive/service.go
@@ -663,60 +663,78 @@ func convertFileInfo(f *drive.File) *DriveFileInfo {
 
 // GetComments retrieves all comments for a Google Drive file.
 func (s *Service) GetComments(fileID string) ([]CommentData, error) {
-	const fields = "comments(id,content,author(displayName),createdTime,resolved,quotedFileContent," +
+	const fields = "nextPageToken,comments(id,content,author(displayName),createdTime,resolved,quotedFileContent," +
 		"replies(content,author(displayName),createdTime))"
 
-	commentList, err := s.client.Comments.List(fileID).Fields(fields).Do()
-	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve comments: %w", err)
-	}
+	var comments []CommentData
 
-	comments := make([]CommentData, 0, len(commentList.Comments))
+	pageToken := ""
+	commentNumber := 1
 
-	for i, c := range commentList.Comments {
-		comment := CommentData{
-			ID:            c.Id,
-			Content:       c.Content,
-			Resolved:      c.Resolved,
-			CommentNumber: i + 1,
+	for {
+		req := s.client.Comments.List(fileID).Fields(fields).PageSize(100)
+
+		if pageToken != "" {
+			req = req.PageToken(pageToken)
 		}
 
-		if c.Author != nil {
-			comment.Author = c.Author.DisplayName
+		commentList, err := req.Do()
+		if err != nil {
+			return nil, fmt.Errorf("unable to retrieve comments: %w", err)
 		}
 
-		if c.QuotedFileContent != nil {
-			comment.QuotedText = c.QuotedFileContent.Value
-		}
-
-		if c.CreatedTime != "" {
-			if t, err := time.Parse(time.RFC3339, c.CreatedTime); err == nil {
-				comment.CreatedTime = t.Format("2006-01-02 15:04")
+		for _, c := range commentList.Comments {
+			comment := CommentData{
+				ID:            c.Id,
+				Content:       c.Content,
+				Resolved:      c.Resolved,
+				CommentNumber: commentNumber,
 			}
-		}
+			commentNumber++
 
-		if len(c.Replies) > 0 {
-			comment.Replies = make([]ReplyData, 0, len(c.Replies))
-			for _, r := range c.Replies {
-				reply := ReplyData{
-					Content: r.Content,
+			if c.Author != nil {
+				comment.Author = c.Author.DisplayName
+			}
+
+			if c.QuotedFileContent != nil {
+				comment.QuotedText = c.QuotedFileContent.Value
+			}
+
+			if c.CreatedTime != "" {
+				if t, err := time.Parse(time.RFC3339, c.CreatedTime); err == nil {
+					comment.CreatedTime = t.Format("2006-01-02 15:04")
 				}
+			}
 
-				if r.Author != nil {
-					reply.Author = r.Author.DisplayName
-				}
-
-				if r.CreatedTime != "" {
-					if t, err := time.Parse(time.RFC3339, r.CreatedTime); err == nil {
-						reply.CreatedTime = t.Format("2006-01-02 15:04")
+			if len(c.Replies) > 0 {
+				comment.Replies = make([]ReplyData, 0, len(c.Replies))
+				for _, r := range c.Replies {
+					reply := ReplyData{
+						Content: r.Content,
 					}
-				}
 
-				comment.Replies = append(comment.Replies, reply)
+					if r.Author != nil {
+						reply.Author = r.Author.DisplayName
+					}
+
+					if r.CreatedTime != "" {
+						if t, err := time.Parse(time.RFC3339, r.CreatedTime); err == nil {
+							reply.CreatedTime = t.Format("2006-01-02 15:04")
+						}
+					}
+
+					comment.Replies = append(comment.Replies, reply)
+				}
 			}
+
+			comments = append(comments, comment)
 		}
 
-		comments = append(comments, comment)
+		if commentList.NextPageToken == "" {
+			break
+		}
+
+		pageToken = commentList.NextPageToken
 	}
 
 	return comments, nil

--- a/internal/sources/google/drive/types.go
+++ b/internal/sources/google/drive/types.go
@@ -42,3 +42,22 @@ type SharedDriveInfo struct {
 	ID   string
 	Name string
 }
+
+// CommentData represents a comment on a Google Drive document.
+type CommentData struct {
+	ID            string
+	QuotedText    string
+	Author        string
+	Content       string
+	CreatedTime   string
+	Resolved      bool
+	Replies       []ReplyData
+	CommentNumber int
+}
+
+// ReplyData represents a reply to a comment.
+type ReplyData struct {
+	Author      string
+	Content     string
+	CreatedTime string
+}


### PR DESCRIPTION
Add building blocks for exporting Google Drive document comments as markdown footnotes. Callers can use GetComments() to fetch comment data, InsertCommentMarkers() to add inline [^comment-N] references, and FormatCommentsAsFootnotes() to render the comments section.

Also fix extractFileIDFromDocsURL and extractFileIDFromDriveURL to strip URL fragments (#heading=h.xyz), not just query parameters.

Assisted-by: Claude Code (Opus 4.6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--comments` flag to `drive fetch` to include Drive comments in Markdown output.
  * When generating Markdown, comments are inserted as inline markers and appended as formatted footnotes.

* **Behavior Changes / Bug Fixes**
  * Non-Markdown export now streams raw content directly to stdout and ignores `--comments` (prints a runtime warning).

* **Tests**
  * Added unit tests covering comment formatting, marker insertion, and file-ID URL parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->