### PR TITLE
feat: cross-source reference resolution

### DIFF
--- a/internal/resolve/drive_resolver.go
+++ b/internal/resolve/drive_resolver.go
@@ -101,16 +101,19 @@ func (r *DriveResolver) Resolve(_ context.Context, rawURL string) (models.FullIt
 		itemType = "presentation"
 	}
 
-	now := time.Now()
+	updatedAt := meta.ModifiedTime
+	if updatedAt.IsZero() {
+		updatedAt = time.Now()
+	}
 
 	item := &models.BasicItem{
-		ID:         "drive_" + fileID,
+		ID:         fileID,
 		Title:      meta.Name,
 		Content:    content,
 		SourceType: "google_drive",
 		ItemType:   itemType,
-		CreatedAt:  now,
-		UpdatedAt:  now,
+		CreatedAt:  updatedAt,
+		UpdatedAt:  updatedAt,
 		Tags:       []string{"resolved"},
 		Metadata: map[string]interface{}{
 			"mime_type":     meta.MimeType,

--- a/internal/resolve/drive_resolver.go
+++ b/internal/resolve/drive_resolver.go
@@ -1,0 +1,125 @@
+package resolve
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"pkm-sync/internal/sources/google/drive"
+	"pkm-sync/pkg/models"
+)
+
+// driveClient is the subset of drive.Service used by DriveResolver.
+// Defined as an interface so tests can inject a mock without a live Drive API.
+type driveClient interface {
+	GetFileMetadata(fileID string) (*models.DriveFile, error)
+	ExportAsString(fileID, exportMimeType string, convertToMarkdown bool, maxBytes int64) (string, error)
+}
+
+// DriveResolver resolves Google Drive and Google Docs URLs to FullItems.
+type DriveResolver struct {
+	svc     driveClient
+	cfg     models.DriveSourceConfig
+	pattern *regexp.Regexp
+}
+
+// NewDriveResolver creates a DriveResolver backed by the given drive.Service.
+func NewDriveResolver(svc *drive.Service, cfg models.DriveSourceConfig) *DriveResolver {
+	return &DriveResolver{
+		svc:     svc,
+		cfg:     cfg,
+		pattern: regexp.MustCompile(`(?i)https?://(?:docs|drive)\.google\.com/`),
+	}
+}
+
+// Name implements interfaces.Resolver.
+func (r *DriveResolver) Name() string { return "drive" }
+
+// CanResolve implements interfaces.Resolver.
+func (r *DriveResolver) CanResolve(rawURL string) bool {
+	return r.pattern.MatchString(rawURL)
+}
+
+// Resolve implements interfaces.Resolver.
+func (r *DriveResolver) Resolve(_ context.Context, rawURL string) (models.FullItem, error) {
+	fileID, err := drive.ExtractFileID(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("drive resolver: cannot extract file ID from %q: %w", rawURL, err)
+	}
+
+	meta, err := r.svc.GetFileMetadata(fileID)
+	if err != nil {
+		return nil, fmt.Errorf("drive resolver: metadata fetch failed for %q: %w", fileID, err)
+	}
+
+	// Determine export format based on MIME type and config preferences.
+	var format string
+
+	switch meta.MimeType {
+	case drive.MimeTypeGoogleDoc:
+		format = r.cfg.DocExportFormat
+		if format == "" {
+			format = drive.FormatMD
+		}
+	case drive.MimeTypeGoogleSheet:
+		format = r.cfg.SheetExportFormat
+		if format == "" {
+			format = drive.FormatCSV
+		}
+	case drive.MimeTypeGooglePresentation:
+		format = r.cfg.SlideExportFormat
+		if format == "" {
+			format = drive.FormatTXT
+		}
+	default:
+		return nil, fmt.Errorf("drive resolver: unsupported MIME type %q for file %q", meta.MimeType, fileID)
+	}
+
+	exportMIME, err := drive.GetExportMimeType(meta.MimeType, format)
+	if err != nil {
+		return nil, fmt.Errorf("drive resolver: %w", err)
+	}
+
+	convertToMarkdown := format == drive.FormatMD
+
+	content, err := r.svc.ExportAsString(fileID, exportMIME, convertToMarkdown, r.cfg.MaxFileSizeBytes)
+	if err != nil {
+		return nil, fmt.Errorf("drive resolver: export failed for %q: %w", fileID, err)
+	}
+
+	// Map MIME type to item type string.
+	var itemType string
+
+	switch meta.MimeType {
+	case drive.MimeTypeGoogleDoc:
+		itemType = "document"
+	case drive.MimeTypeGoogleSheet:
+		itemType = "spreadsheet"
+	case drive.MimeTypeGooglePresentation:
+		itemType = "presentation"
+	}
+
+	now := time.Now()
+
+	item := &models.BasicItem{
+		ID:         "drive_" + fileID,
+		Title:      meta.Name,
+		Content:    content,
+		SourceType: "google_drive",
+		ItemType:   itemType,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+		Tags:       []string{"resolved"},
+		Metadata: map[string]interface{}{
+			"mime_type":     meta.MimeType,
+			"web_view_link": meta.WebViewLink,
+			"owners":        meta.Owners,
+		},
+		Links: []models.Link{
+			{URL: rawURL, Title: meta.Name, Type: "document"},
+		},
+	}
+
+	return item, nil
+}

--- a/internal/resolve/drive_resolver.go
+++ b/internal/resolve/drive_resolver.go
@@ -24,8 +24,9 @@ type DriveResolver struct {
 	pattern *regexp.Regexp
 }
 
-// NewDriveResolver creates a DriveResolver backed by the given drive.Service.
-func NewDriveResolver(svc *drive.Service, cfg models.DriveSourceConfig) *DriveResolver {
+// NewDriveResolver creates a DriveResolver backed by the given driveClient.
+// Accepts the driveClient interface so tests can inject mocks directly.
+func NewDriveResolver(svc driveClient, cfg models.DriveSourceConfig) *DriveResolver {
 	return &DriveResolver{
 		svc:     svc,
 		cfg:     cfg,

--- a/internal/resolve/drive_resolver_test.go
+++ b/internal/resolve/drive_resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"pkm-sync/pkg/models"
 )
@@ -49,12 +50,14 @@ func TestDriveResolver_CanResolve(t *testing.T) {
 }
 
 func TestDriveResolver_Resolve_GoogleDoc(t *testing.T) {
+	modifiedAt := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	mock := &mockDriveClient{
 		metadata: &models.DriveFile{
-			ID:          "abc123",
-			Name:        "My Report",
-			MimeType:    "application/vnd.google-apps.document",
-			WebViewLink: "https://docs.google.com/document/d/abc123/edit",
+			ID:           "abc123",
+			Name:         "My Report",
+			MimeType:     "application/vnd.google-apps.document",
+			WebViewLink:  "https://docs.google.com/document/d/abc123/edit",
+			ModifiedTime: modifiedAt,
 		},
 		content: "# My Report\n\nContent here.",
 	}
@@ -71,6 +74,10 @@ func TestDriveResolver_Resolve_GoogleDoc(t *testing.T) {
 		t.Fatal("expected a resolved item, got nil")
 	}
 
+	if item.GetID() != "abc123" {
+		t.Errorf("ID = %q, want %q", item.GetID(), "abc123")
+	}
+
 	if item.GetItemType() != "document" {
 		t.Errorf("ItemType = %q, want %q", item.GetItemType(), "document")
 	}
@@ -81,6 +88,10 @@ func TestDriveResolver_Resolve_GoogleDoc(t *testing.T) {
 
 	if item.GetContent() != mock.content {
 		t.Errorf("Content = %q, want %q", item.GetContent(), mock.content)
+	}
+
+	if !item.GetUpdatedAt().Equal(modifiedAt) {
+		t.Errorf("UpdatedAt = %v, want %v", item.GetUpdatedAt(), modifiedAt)
 	}
 }
 

--- a/internal/resolve/drive_resolver_test.go
+++ b/internal/resolve/drive_resolver_test.go
@@ -193,6 +193,7 @@ func TestDriveResolver_Resolve_TaggedAsResolved(t *testing.T) {
 	for _, tag := range tags {
 		if tag == "resolved" {
 			found = true
+
 			break
 		}
 	}
@@ -201,4 +202,3 @@ func TestDriveResolver_Resolve_TaggedAsResolved(t *testing.T) {
 		t.Errorf("resolved item should have 'resolved' tag, got: %v", tags)
 	}
 }
-

--- a/internal/resolve/drive_resolver_test.go
+++ b/internal/resolve/drive_resolver_test.go
@@ -62,8 +62,7 @@ func TestDriveResolver_Resolve_GoogleDoc(t *testing.T) {
 		content: "# My Report\n\nContent here.",
 	}
 
-	r := NewDriveResolver(nil, models.DriveSourceConfig{})
-	r.svc = mock
+	r := NewDriveResolver(mock, models.DriveSourceConfig{})
 
 	item, err := r.Resolve(context.Background(), "https://docs.google.com/document/d/abc123/edit")
 	if err != nil {
@@ -105,8 +104,7 @@ func TestDriveResolver_Resolve_Spreadsheet(t *testing.T) {
 		content: "a,b,c\n1,2,3",
 	}
 
-	r := NewDriveResolver(nil, models.DriveSourceConfig{})
-	r.svc = mock
+	r := NewDriveResolver(mock, models.DriveSourceConfig{})
 
 	item, err := r.Resolve(context.Background(), "https://docs.google.com/spreadsheets/d/sheet1")
 	if err != nil {
@@ -127,8 +125,7 @@ func TestDriveResolver_Resolve_UnsupportedMIME(t *testing.T) {
 		},
 	}
 
-	r := NewDriveResolver(nil, models.DriveSourceConfig{})
-	r.svc = mock
+	r := NewDriveResolver(mock, models.DriveSourceConfig{})
 
 	_, err := r.Resolve(context.Background(), "https://drive.google.com/file/d/pdf1/view")
 	if err == nil {
@@ -141,8 +138,7 @@ func TestDriveResolver_Resolve_MetadataError(t *testing.T) {
 		metadataErr: errors.New("not found"),
 	}
 
-	r := NewDriveResolver(nil, models.DriveSourceConfig{})
-	r.svc = mock
+	r := NewDriveResolver(mock, models.DriveSourceConfig{})
 
 	_, err := r.Resolve(context.Background(), "https://docs.google.com/document/d/missing/edit")
 	if err == nil {
@@ -160,8 +156,7 @@ func TestDriveResolver_Resolve_ExportError(t *testing.T) {
 		contentErr: errors.New("export failed"),
 	}
 
-	r := NewDriveResolver(nil, models.DriveSourceConfig{})
-	r.svc = mock
+	r := NewDriveResolver(mock, models.DriveSourceConfig{})
 
 	_, err := r.Resolve(context.Background(), "https://docs.google.com/document/d/doc1/edit")
 	if err == nil {
@@ -170,8 +165,7 @@ func TestDriveResolver_Resolve_ExportError(t *testing.T) {
 }
 
 func TestDriveResolver_Resolve_BadURL(t *testing.T) {
-	r := NewDriveResolver(nil, models.DriveSourceConfig{})
-	r.svc = &mockDriveClient{}
+	r := NewDriveResolver(&mockDriveClient{}, models.DriveSourceConfig{})
 
 	// URL that passes CanResolve but has no extractable file ID.
 	_, err := r.Resolve(context.Background(), "https://docs.google.com/")
@@ -190,8 +184,7 @@ func TestDriveResolver_Resolve_TaggedAsResolved(t *testing.T) {
 		content: "content",
 	}
 
-	r := NewDriveResolver(nil, models.DriveSourceConfig{})
-	r.svc = mock
+	r := NewDriveResolver(mock, models.DriveSourceConfig{})
 
 	item, err := r.Resolve(context.Background(), "https://docs.google.com/document/d/doc2/edit")
 	if err != nil {

--- a/internal/resolve/drive_resolver_test.go
+++ b/internal/resolve/drive_resolver_test.go
@@ -1,0 +1,204 @@
+package resolve
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"pkm-sync/pkg/models"
+)
+
+// mockDriveClient implements driveClient for tests.
+type mockDriveClient struct {
+	metadata    *models.DriveFile
+	metadataErr error
+	content     string
+	contentErr  error
+}
+
+func (m *mockDriveClient) GetFileMetadata(_ string) (*models.DriveFile, error) {
+	return m.metadata, m.metadataErr
+}
+
+func (m *mockDriveClient) ExportAsString(_, _ string, _ bool, _ int64) (string, error) {
+	return m.content, m.contentErr
+}
+
+func TestDriveResolver_CanResolve(t *testing.T) {
+	r := NewDriveResolver(nil, models.DriveSourceConfig{})
+
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{"https://docs.google.com/document/d/abc/edit", true},
+		{"https://drive.google.com/file/d/abc/view", true},
+		{"https://docs.google.com/spreadsheets/d/abc", true},
+		{"https://docs.google.com/presentation/d/abc", true},
+		{"https://slack.com/archives/C123", false},
+		{"https://example.com", false},
+		{"https://jira.example.com/browse/PROJ-1", false},
+	}
+
+	for _, tt := range tests {
+		got := r.CanResolve(tt.url)
+		if got != tt.want {
+			t.Errorf("CanResolve(%q) = %v, want %v", tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestDriveResolver_Resolve_GoogleDoc(t *testing.T) {
+	mock := &mockDriveClient{
+		metadata: &models.DriveFile{
+			ID:          "abc123",
+			Name:        "My Report",
+			MimeType:    "application/vnd.google-apps.document",
+			WebViewLink: "https://docs.google.com/document/d/abc123/edit",
+		},
+		content: "# My Report\n\nContent here.",
+	}
+
+	r := NewDriveResolver(nil, models.DriveSourceConfig{})
+	r.svc = mock
+
+	item, err := r.Resolve(context.Background(), "https://docs.google.com/document/d/abc123/edit")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if item == nil {
+		t.Fatal("expected a resolved item, got nil")
+	}
+
+	if item.GetItemType() != "document" {
+		t.Errorf("ItemType = %q, want %q", item.GetItemType(), "document")
+	}
+
+	if item.GetSourceType() != "google_drive" {
+		t.Errorf("SourceType = %q, want %q", item.GetSourceType(), "google_drive")
+	}
+
+	if item.GetContent() != mock.content {
+		t.Errorf("Content = %q, want %q", item.GetContent(), mock.content)
+	}
+}
+
+func TestDriveResolver_Resolve_Spreadsheet(t *testing.T) {
+	mock := &mockDriveClient{
+		metadata: &models.DriveFile{
+			ID:       "sheet1",
+			Name:     "Budget",
+			MimeType: "application/vnd.google-apps.spreadsheet",
+		},
+		content: "a,b,c\n1,2,3",
+	}
+
+	r := NewDriveResolver(nil, models.DriveSourceConfig{})
+	r.svc = mock
+
+	item, err := r.Resolve(context.Background(), "https://docs.google.com/spreadsheets/d/sheet1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if item.GetItemType() != "spreadsheet" {
+		t.Errorf("ItemType = %q, want %q", item.GetItemType(), "spreadsheet")
+	}
+}
+
+func TestDriveResolver_Resolve_UnsupportedMIME(t *testing.T) {
+	mock := &mockDriveClient{
+		metadata: &models.DriveFile{
+			ID:       "pdf1",
+			Name:     "doc.pdf",
+			MimeType: "application/pdf",
+		},
+	}
+
+	r := NewDriveResolver(nil, models.DriveSourceConfig{})
+	r.svc = mock
+
+	_, err := r.Resolve(context.Background(), "https://drive.google.com/file/d/pdf1/view")
+	if err == nil {
+		t.Fatal("expected error for unsupported MIME type, got nil")
+	}
+}
+
+func TestDriveResolver_Resolve_MetadataError(t *testing.T) {
+	mock := &mockDriveClient{
+		metadataErr: errors.New("not found"),
+	}
+
+	r := NewDriveResolver(nil, models.DriveSourceConfig{})
+	r.svc = mock
+
+	_, err := r.Resolve(context.Background(), "https://docs.google.com/document/d/missing/edit")
+	if err == nil {
+		t.Fatal("expected error from metadata failure, got nil")
+	}
+}
+
+func TestDriveResolver_Resolve_ExportError(t *testing.T) {
+	mock := &mockDriveClient{
+		metadata: &models.DriveFile{
+			ID:       "doc1",
+			Name:     "Doc",
+			MimeType: "application/vnd.google-apps.document",
+		},
+		contentErr: errors.New("export failed"),
+	}
+
+	r := NewDriveResolver(nil, models.DriveSourceConfig{})
+	r.svc = mock
+
+	_, err := r.Resolve(context.Background(), "https://docs.google.com/document/d/doc1/edit")
+	if err == nil {
+		t.Fatal("expected error from export failure, got nil")
+	}
+}
+
+func TestDriveResolver_Resolve_BadURL(t *testing.T) {
+	r := NewDriveResolver(nil, models.DriveSourceConfig{})
+	r.svc = &mockDriveClient{}
+
+	// URL that passes CanResolve but has no extractable file ID.
+	_, err := r.Resolve(context.Background(), "https://docs.google.com/")
+	if err == nil {
+		t.Fatal("expected error for URL with no file ID, got nil")
+	}
+}
+
+func TestDriveResolver_Resolve_TaggedAsResolved(t *testing.T) {
+	mock := &mockDriveClient{
+		metadata: &models.DriveFile{
+			ID:       "doc2",
+			Name:     "Tagged Doc",
+			MimeType: "application/vnd.google-apps.document",
+		},
+		content: "content",
+	}
+
+	r := NewDriveResolver(nil, models.DriveSourceConfig{})
+	r.svc = mock
+
+	item, err := r.Resolve(context.Background(), "https://docs.google.com/document/d/doc2/edit")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tags := item.GetTags()
+	found := false
+
+	for _, tag := range tags {
+		if tag == "resolved" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("resolved item should have 'resolved' tag, got: %v", tags)
+	}
+}
+

--- a/internal/resolve/engine.go
+++ b/internal/resolve/engine.go
@@ -1,0 +1,225 @@
+// Package resolve implements cross-source reference resolution.
+// When synced items contain links to content in other sources (e.g. a Slack
+// message linking to a Jira issue), the engine fetches the referenced content
+// and appends it to the item set so it flows through the normal Sink pipeline.
+package resolve
+
+import (
+	"context"
+	"log/slog"
+	"net/url"
+	"strings"
+
+	"pkm-sync/pkg/interfaces"
+	"pkm-sync/pkg/models"
+)
+
+// Config controls the behaviour of a single Resolve call.
+type Config struct {
+	// MaxDepth is the maximum number of resolution rounds to run.
+	// 0 is treated as 1 — at least one round is always attempted.
+	MaxDepth int
+}
+
+// Engine runs multi-depth cross-source reference resolution.
+type Engine struct {
+	resolvers []interfaces.Resolver
+}
+
+// NewEngine creates an Engine backed by the given resolvers.
+// Resolver order matters: the first resolver whose CanResolve returns true
+// for a given URL wins.
+func NewEngine(resolvers []interfaces.Resolver) *Engine {
+	return &Engine{resolvers: resolvers}
+}
+
+// Resolve runs up to cfg.MaxDepth rounds of link scanning and resolution
+// against items. The returned slice always includes the original items;
+// resolved items are appended after them.
+//
+// Each unique URL is fetched at most once per Resolve call (dedup by
+// normalised URL). Resolver errors are logged and skipped — they do not abort
+// the run. Items returned by resolvers flow into subsequent rounds so that
+// transitive references are followed up to cfg.MaxDepth.
+func (e *Engine) Resolve(
+	ctx context.Context,
+	items []models.FullItem,
+	cfg Config,
+) ([]models.FullItem, error) {
+	if len(e.resolvers) == 0 {
+		return items, nil
+	}
+
+	maxDepth := cfg.MaxDepth
+	if maxDepth <= 0 {
+		maxDepth = 1
+	}
+
+	// fetched tracks normalised URLs already resolved in this call.
+	fetched := make(map[string]bool)
+	// allItems accumulates original + resolved items across all rounds.
+	allItems := make([]models.FullItem, len(items))
+	copy(allItems, items)
+
+	for depth := 0; depth < maxDepth; depth++ {
+		// Collect URLs from all current items that haven't been fetched yet.
+		newURLs := e.collectNewURLs(allItems, fetched)
+		if len(newURLs) == 0 {
+			break
+		}
+
+		var resolved []models.FullItem
+
+		for _, rawURL := range newURLs {
+			norm := normaliseURL(rawURL)
+			fetched[norm] = true
+
+			item, err := e.resolveOne(ctx, rawURL)
+			if err != nil {
+				slog.Warn("Reference resolution failed", "url", rawURL, "error", err)
+				continue
+			}
+
+			if item == nil {
+				// Resolver signalled skip (e.g. freshness check passed).
+				continue
+			}
+
+			annotateReferenced(item, rawURL)
+			resolved = append(resolved, item)
+		}
+
+		if len(resolved) == 0 {
+			break
+		}
+
+		// Cross-reference: tell referring items which resolved IDs they point to.
+		crossReference(allItems, resolved)
+
+		allItems = append(allItems, resolved...)
+
+		slog.Info("Resolved references",
+			"depth", depth+1,
+			"new_items", len(resolved),
+			"total_items", len(allItems),
+		)
+	}
+
+	return allItems, nil
+}
+
+// resolveOne tries each resolver in order and returns the first match.
+func (e *Engine) resolveOne(ctx context.Context, rawURL string) (models.FullItem, error) {
+	for _, r := range e.resolvers {
+		if r.CanResolve(rawURL) {
+			return r.Resolve(ctx, rawURL)
+		}
+	}
+
+	return nil, nil // no resolver matched
+}
+
+// collectNewURLs gathers all link URLs from items that have not been fetched yet.
+func (e *Engine) collectNewURLs(items []models.FullItem, fetched map[string]bool) []string {
+	seen := make(map[string]bool)
+	var urls []string
+
+	for _, item := range items {
+		for _, link := range item.GetLinks() {
+			if link.URL == "" {
+				continue
+			}
+
+			norm := normaliseURL(link.URL)
+
+			if fetched[norm] || seen[norm] {
+				continue
+			}
+
+			// Only include URLs that at least one resolver can handle.
+			for _, r := range e.resolvers {
+				if r.CanResolve(link.URL) {
+					seen[norm] = true
+					urls = append(urls, link.URL)
+
+					break
+				}
+			}
+		}
+	}
+
+	return urls
+}
+
+// annotateReferenced adds "referenced_by" metadata to a resolved item.
+func annotateReferenced(item models.FullItem, sourceURL string) {
+	meta := item.GetMetadata()
+	if meta == nil {
+		meta = make(map[string]interface{})
+	}
+
+	existing, _ := meta["referenced_by"].([]string)
+	meta["referenced_by"] = append(existing, sourceURL)
+	item.SetMetadata(meta)
+}
+
+// crossReference adds "resolved_refs" metadata to items whose links point to
+// any of the newly resolved items (matched by the URL that was resolved).
+func crossReference(existing []models.FullItem, resolved []models.FullItem) {
+	// Build a set of URLs that produced resolved items, keyed by normalised URL.
+	// We store the resolved item ID so referring items can point by ID too.
+	resolvedByURL := make(map[string]string, len(resolved))
+
+	for _, r := range resolved {
+		for _, link := range r.GetLinks() {
+			if link.URL != "" {
+				resolvedByURL[normaliseURL(link.URL)] = r.GetID()
+			}
+		}
+	}
+
+	for _, item := range existing {
+		for _, link := range item.GetLinks() {
+			resolvedID, ok := resolvedByURL[normaliseURL(link.URL)]
+			if !ok {
+				continue
+			}
+
+			meta := item.GetMetadata()
+			if meta == nil {
+				meta = make(map[string]interface{})
+			}
+
+			refs, _ := meta["resolved_refs"].([]string)
+
+			// Avoid duplicates.
+			alreadyPresent := false
+			for _, r := range refs {
+				if r == resolvedID {
+					alreadyPresent = true
+					break
+				}
+			}
+
+			if !alreadyPresent {
+				meta["resolved_refs"] = append(refs, resolvedID)
+				item.SetMetadata(meta)
+			}
+		}
+	}
+}
+
+// normaliseURL strips trailing slashes and lowercases the scheme+host so that
+// http://Example.com/Foo and https://example.com/Foo/ don't count as different.
+func normaliseURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return strings.ToLower(strings.TrimRight(raw, "/"))
+	}
+
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	parsed.Host = strings.ToLower(parsed.Host)
+	result := parsed.String()
+
+	return strings.TrimRight(result, "/")
+}

--- a/internal/resolve/engine.go
+++ b/internal/resolve/engine.go
@@ -62,13 +62,18 @@ func (e *Engine) Resolve(
 	copy(allItems, items)
 
 	for depth := 0; depth < maxDepth; depth++ {
-		// Collect URLs from all current items that haven't been fetched yet.
-		newURLs := e.collectNewURLs(allItems, fetched)
+		// Collect URLs from all current items that haven't been fetched yet,
+		// along with a map of which item IDs link to each target URL.
+		newURLs, referrerMap := e.collectNewURLs(allItems, fetched)
 		if len(newURLs) == 0 {
 			break
 		}
 
 		var resolved []models.FullItem
+
+		// resolvedURLToID maps normalised rawURL → resolved item ID, keyed by the
+		// URL used to resolve rather than the resolved item's outbound links.
+		resolvedURLToID := make(map[string]string, len(newURLs))
 
 		for _, rawURL := range newURLs {
 			norm := normaliseURL(rawURL)
@@ -86,7 +91,10 @@ func (e *Engine) Resolve(
 				continue
 			}
 
-			annotateReferenced(item, rawURL)
+			// Record which items referred to this URL so the resolved item
+			// knows who links to it.
+			annotateReferenced(item, referrerMap[norm])
+			resolvedURLToID[norm] = item.GetID()
 			resolved = append(resolved, item)
 		}
 
@@ -95,7 +103,7 @@ func (e *Engine) Resolve(
 		}
 
 		// Cross-reference: tell referring items which resolved IDs they point to.
-		crossReference(allItems, resolved)
+		crossReference(allItems, resolvedURLToID)
 
 		allItems = append(allItems, resolved...)
 
@@ -120,11 +128,16 @@ func (e *Engine) resolveOne(ctx context.Context, rawURL string) (models.FullItem
 	return nil, nil // no resolver matched
 }
 
-// collectNewURLs gathers all link URLs from items that have not been fetched yet.
-func (e *Engine) collectNewURLs(items []models.FullItem, fetched map[string]bool) []string {
+// collectNewURLs gathers resolvable link URLs not yet fetched, together with a
+// referrerMap that maps each normalised target URL to the IDs of items that
+// link to it. The referrerMap is used to populate "referenced_by" metadata on
+// resolved items.
+func (e *Engine) collectNewURLs(
+	items []models.FullItem,
+	fetched map[string]bool,
+) (urls []string, referrerMap map[string][]string) {
 	seen := make(map[string]bool)
-
-	var urls []string
+	referrerMap = make(map[string][]string)
 
 	for _, item := range items {
 		for _, link := range item.GetLinks() {
@@ -133,6 +146,9 @@ func (e *Engine) collectNewURLs(items []models.FullItem, fetched map[string]bool
 			}
 
 			norm := normaliseURL(link.URL)
+
+			// Always track referrers regardless of dedup state.
+			referrerMap[norm] = appendUnique(referrerMap[norm], item.GetID())
 
 			if fetched[norm] || seen[norm] {
 				continue
@@ -151,39 +167,42 @@ func (e *Engine) collectNewURLs(items []models.FullItem, fetched map[string]bool
 		}
 	}
 
-	return urls
+	return urls, referrerMap
 }
 
-// annotateReferenced adds "referenced_by" metadata to a resolved item.
-func annotateReferenced(item models.FullItem, sourceURL string) {
+// annotateReferenced sets "referenced_by" metadata on a resolved item to the
+// IDs of the items that contained the link to it.
+func annotateReferenced(item models.FullItem, referrerIDs []string) {
+	if len(referrerIDs) == 0 {
+		return
+	}
+
 	meta := item.GetMetadata()
 	if meta == nil {
 		meta = make(map[string]interface{})
 	}
 
 	existing, _ := meta["referenced_by"].([]string)
-	meta["referenced_by"] = append(existing, sourceURL)
+	for _, id := range referrerIDs {
+		existing = appendUnique(existing, id)
+	}
+
+	meta["referenced_by"] = existing
 	item.SetMetadata(meta)
 }
 
-// crossReference adds "resolved_refs" metadata to items whose links point to
-// any of the newly resolved items (matched by the URL that was resolved).
-func crossReference(existing []models.FullItem, resolved []models.FullItem) {
-	// Build a set of URLs that produced resolved items, keyed by normalised URL.
-	// We store the resolved item ID so referring items can point by ID too.
-	resolvedByURL := make(map[string]string, len(resolved))
-
-	for _, r := range resolved {
-		for _, link := range r.GetLinks() {
-			if link.URL != "" {
-				resolvedByURL[normaliseURL(link.URL)] = r.GetID()
-			}
-		}
-	}
-
+// crossReference adds "resolved_refs" metadata to existing items whose links
+// were resolved. resolvedURLToID maps normalised target URL → resolved item ID,
+// built directly from the rawURLs used to resolve each item so that items with
+// no self-link (e.g. some Jira items) are still cross-referenced correctly.
+func crossReference(existing []models.FullItem, resolvedURLToID map[string]string) {
 	for _, item := range existing {
 		for _, link := range item.GetLinks() {
-			resolvedID, ok := resolvedByURL[normaliseURL(link.URL)]
+			if link.URL == "" {
+				continue
+			}
+
+			resolvedID, ok := resolvedURLToID[normaliseURL(link.URL)]
 			if !ok {
 				continue
 			}
@@ -194,24 +213,21 @@ func crossReference(existing []models.FullItem, resolved []models.FullItem) {
 			}
 
 			refs, _ := meta["resolved_refs"].([]string)
-
-			// Avoid duplicates.
-			alreadyPresent := false
-
-			for _, r := range refs {
-				if r == resolvedID {
-					alreadyPresent = true
-
-					break
-				}
-			}
-
-			if !alreadyPresent {
-				meta["resolved_refs"] = append(refs, resolvedID)
-				item.SetMetadata(meta)
-			}
+			meta["resolved_refs"] = appendUnique(refs, resolvedID)
+			item.SetMetadata(meta)
 		}
 	}
+}
+
+// appendUnique appends s to slice only if it is not already present.
+func appendUnique(slice []string, s string) []string {
+	for _, v := range slice {
+		if v == s {
+			return slice
+		}
+	}
+
+	return append(slice, s)
 }
 
 // normaliseURL lowercases the scheme and host and strips trailing slashes.

--- a/internal/resolve/engine.go
+++ b/internal/resolve/engine.go
@@ -171,7 +171,7 @@ func (e *Engine) collectNewURLs(
 }
 
 // annotateReferenced sets "referenced_by" metadata on a resolved item to the
-// IDs of the items that contained the link to it.
+// IDs of the items that contained the link to it. Uses a map for O(1) dedup.
 func annotateReferenced(item models.FullItem, referrerIDs []string) {
 	if len(referrerIDs) == 0 {
 		return
@@ -183,8 +183,18 @@ func annotateReferenced(item models.FullItem, referrerIDs []string) {
 	}
 
 	existing, _ := meta["referenced_by"].([]string)
+
+	// Build seen-set once for O(1) membership checks across all referrerIDs.
+	seen := make(map[string]struct{}, len(existing)+len(referrerIDs))
+	for _, id := range existing {
+		seen[id] = struct{}{}
+	}
+
 	for _, id := range referrerIDs {
-		existing = appendUnique(existing, id)
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			existing = append(existing, id)
+		}
 	}
 
 	meta["referenced_by"] = existing
@@ -219,12 +229,16 @@ func crossReference(existing []models.FullItem, resolvedURLToID map[string]strin
 	}
 }
 
-// appendUnique appends s to slice only if it is not already present.
+// appendUnique appends s to slice only if not already present.
+// Uses a map for O(1) membership checks, preserving insertion order.
 func appendUnique(slice []string, s string) []string {
+	seen := make(map[string]struct{}, len(slice))
 	for _, v := range slice {
-		if v == s {
-			return slice
-		}
+		seen[v] = struct{}{}
+	}
+
+	if _, ok := seen[s]; ok {
+		return slice
 	}
 
 	return append(slice, s)

--- a/internal/resolve/engine.go
+++ b/internal/resolve/engine.go
@@ -14,7 +14,7 @@ import (
 	"pkm-sync/pkg/models"
 )
 
-// Config controls the behaviour of a single Resolve call.
+// Config controls the behavior of a single Resolve call.
 type Config struct {
 	// MaxDepth is the maximum number of resolution rounds to run.
 	// 0 is treated as 1 — at least one round is always attempted.
@@ -77,11 +77,12 @@ func (e *Engine) Resolve(
 			item, err := e.resolveOne(ctx, rawURL)
 			if err != nil {
 				slog.Warn("Reference resolution failed", "url", rawURL, "error", err)
+
 				continue
 			}
 
 			if item == nil {
-				// Resolver signalled skip (e.g. freshness check passed).
+				// Resolver signaled skip (e.g. freshness check passed).
 				continue
 			}
 
@@ -122,6 +123,7 @@ func (e *Engine) resolveOne(ctx context.Context, rawURL string) (models.FullItem
 // collectNewURLs gathers all link URLs from items that have not been fetched yet.
 func (e *Engine) collectNewURLs(items []models.FullItem, fetched map[string]bool) []string {
 	seen := make(map[string]bool)
+
 	var urls []string
 
 	for _, item := range items {
@@ -140,6 +142,7 @@ func (e *Engine) collectNewURLs(items []models.FullItem, fetched map[string]bool
 			for _, r := range e.resolvers {
 				if r.CanResolve(link.URL) {
 					seen[norm] = true
+
 					urls = append(urls, link.URL)
 
 					break
@@ -194,9 +197,11 @@ func crossReference(existing []models.FullItem, resolved []models.FullItem) {
 
 			// Avoid duplicates.
 			alreadyPresent := false
+
 			for _, r := range refs {
 				if r == resolvedID {
 					alreadyPresent = true
+
 					break
 				}
 			}

--- a/internal/resolve/engine.go
+++ b/internal/resolve/engine.go
@@ -214,8 +214,10 @@ func crossReference(existing []models.FullItem, resolved []models.FullItem) {
 	}
 }
 
-// normaliseURL strips trailing slashes and lowercases the scheme+host so that
-// http://Example.com/Foo and https://example.com/Foo/ don't count as different.
+// normaliseURL lowercases the scheme and host and strips trailing slashes.
+// Path casing is preserved: some targets are case-sensitive so paths are not
+// lowercased. http://Example.com/path/ and https://example.com/path resolve to
+// the same key, but https://example.com/Path and /path are distinct.
 func normaliseURL(raw string) string {
 	parsed, err := url.Parse(raw)
 	if err != nil {

--- a/internal/resolve/engine_test.go
+++ b/internal/resolve/engine_test.go
@@ -103,6 +103,7 @@ func TestEngine_DeduplicatesURLs(t *testing.T) {
 		canHandle: func(url string) bool { return url == targetURL },
 		resolve: func(_ context.Context, url string) (models.FullItem, error) {
 			callCount.Add(1)
+
 			return makeResolvedItem("resolved-1", url), nil
 		},
 	}

--- a/internal/resolve/engine_test.go
+++ b/internal/resolve/engine_test.go
@@ -338,13 +338,14 @@ func TestEngine_OriginalItemsAlwaysIncluded(t *testing.T) {
 func TestEngine_FirstResolverWins(t *testing.T) {
 	const targetURL = "https://example.com/item"
 
-	calls := []string{}
+	var firstCalled, secondCalled atomic.Bool
 
 	r1 := &mockResolver{
 		name:      "first",
 		canHandle: func(url string) bool { return true },
 		resolve: func(_ context.Context, url string) (models.FullItem, error) {
-			calls = append(calls, "first")
+			firstCalled.Store(true)
+
 			return makeResolvedItem("from-first", url), nil
 		},
 	}
@@ -353,7 +354,8 @@ func TestEngine_FirstResolverWins(t *testing.T) {
 		name:      "second",
 		canHandle: func(url string) bool { return true },
 		resolve: func(_ context.Context, url string) (models.FullItem, error) {
-			calls = append(calls, "second")
+			secondCalled.Store(true)
+
 			return makeResolvedItem("from-second", url), nil
 		},
 	}
@@ -366,8 +368,9 @@ func TestEngine_FirstResolverWins(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(calls) != 1 || calls[0] != "first" {
-		t.Errorf("only the first matching resolver should be called, got: %v", calls)
+	if !firstCalled.Load() || secondCalled.Load() {
+		t.Errorf("only first resolver should be called: first=%v second=%v",
+			firstCalled.Load(), secondCalled.Load())
 	}
 }
 

--- a/internal/resolve/engine_test.go
+++ b/internal/resolve/engine_test.go
@@ -1,0 +1,396 @@
+package resolve
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"pkm-sync/pkg/interfaces"
+	"pkm-sync/pkg/models"
+)
+
+// --- mock resolver ---
+
+type mockResolver struct {
+	name      string
+	canHandle func(url string) bool
+	resolve   func(ctx context.Context, url string) (models.FullItem, error)
+	calls     atomic.Int64
+}
+
+func (m *mockResolver) Name() string { return m.name }
+
+func (m *mockResolver) CanResolve(url string) bool {
+	return m.canHandle(url)
+}
+
+func (m *mockResolver) Resolve(ctx context.Context, url string) (models.FullItem, error) {
+	m.calls.Add(1)
+	return m.resolve(ctx, url)
+}
+
+var _ interfaces.Resolver = (*mockResolver)(nil)
+
+// makeItem creates a minimal FullItem with a link to the given URL.
+func makeItem(id, linkURL string) models.FullItem {
+	item := models.NewBasicItem(id, id)
+	if linkURL != "" {
+		item.SetLinks([]models.Link{{URL: linkURL, Type: "external"}})
+	}
+
+	return item
+}
+
+// makeResolvedItem returns a FullItem whose own Links point back to sourceURL
+// (simulating a resolver that records the URL it was resolved from).
+func makeResolvedItem(id, sourceURL string) models.FullItem {
+	item := models.NewBasicItem(id, id)
+	item.SetLinks([]models.Link{{URL: sourceURL, Type: "document"}})
+	item.SetMetadata(map[string]interface{}{})
+
+	return item
+}
+
+// --- tests ---
+
+func TestEngine_NoResolvers(t *testing.T) {
+	engine := NewEngine(nil)
+	items := []models.FullItem{makeItem("a", "https://example.com")}
+
+	result, err := engine.Resolve(context.Background(), items, Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Errorf("expected 1 item, got %d", len(result))
+	}
+}
+
+func TestEngine_NoMatchingResolver(t *testing.T) {
+	r := &mockResolver{
+		name:      "noop",
+		canHandle: func(url string) bool { return false },
+		resolve:   func(_ context.Context, _ string) (models.FullItem, error) { return nil, nil },
+	}
+
+	engine := NewEngine([]interfaces.Resolver{r})
+	items := []models.FullItem{makeItem("a", "https://example.com")}
+
+	result, err := engine.Resolve(context.Background(), items, Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Errorf("expected 1 item unchanged, got %d", len(result))
+	}
+
+	if r.calls.Load() != 0 {
+		t.Errorf("resolver should not have been called")
+	}
+}
+
+func TestEngine_DeduplicatesURLs(t *testing.T) {
+	const targetURL = "https://docs.google.com/document/d/abc123"
+
+	callCount := atomic.Int64{}
+	r := &mockResolver{
+		name:      "dedup",
+		canHandle: func(url string) bool { return url == targetURL },
+		resolve: func(_ context.Context, url string) (models.FullItem, error) {
+			callCount.Add(1)
+			return makeResolvedItem("resolved-1", url), nil
+		},
+	}
+
+	engine := NewEngine([]interfaces.Resolver{r})
+
+	// Two items that both link to the same URL.
+	items := []models.FullItem{
+		makeItem("a", targetURL),
+		makeItem("b", targetURL),
+	}
+
+	result, err := engine.Resolve(context.Background(), items, Config{MaxDepth: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if callCount.Load() != 1 {
+		t.Errorf("URL should be resolved exactly once, got %d calls", callCount.Load())
+	}
+
+	// original 2 + 1 resolved
+	if len(result) != 3 {
+		t.Errorf("expected 3 items, got %d", len(result))
+	}
+}
+
+func TestEngine_DepthLimit(t *testing.T) {
+	// depth-1 URL resolves to an item that itself links to depth-2 URL
+	const url1 = "https://jira.example.com/browse/PROJ-1"
+	const url2 = "https://jira.example.com/browse/PROJ-2"
+
+	resolveCount := atomic.Int64{}
+	r := &mockResolver{
+		name:      "jira",
+		canHandle: func(url string) bool { return url == url1 || url == url2 },
+		resolve: func(_ context.Context, url string) (models.FullItem, error) {
+			resolveCount.Add(1)
+			if url == url1 {
+				// The resolved item itself links to url2.
+				item := makeResolvedItem("issue-1", url1)
+				item.SetLinks([]models.Link{{URL: url2, Type: "external"}})
+				return item, nil
+			}
+
+			return makeResolvedItem("issue-2", url2), nil
+		},
+	}
+
+	engine := NewEngine([]interfaces.Resolver{r})
+	items := []models.FullItem{makeItem("msg", url1)}
+
+	// Depth 1: should only resolve url1, NOT url2.
+	result, err := engine.Resolve(context.Background(), items, Config{MaxDepth: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resolveCount.Load() != 1 {
+		t.Errorf("depth=1: expected 1 resolve call, got %d", resolveCount.Load())
+	}
+
+	// original + issue-1
+	if len(result) != 2 {
+		t.Errorf("depth=1: expected 2 items, got %d", len(result))
+	}
+
+	// Reset and run depth 2: should resolve url1 then url2.
+	resolveCount.Store(0)
+
+	result2, err := engine.Resolve(context.Background(), items, Config{MaxDepth: 2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resolveCount.Load() != 2 {
+		t.Errorf("depth=2: expected 2 resolve calls, got %d", resolveCount.Load())
+	}
+
+	// original + issue-1 + issue-2
+	if len(result2) != 3 {
+		t.Errorf("depth=2: expected 3 items, got %d", len(result2))
+	}
+}
+
+func TestEngine_DefaultDepthIsOne(t *testing.T) {
+	const url1 = "https://example.com/a"
+	const url2 = "https://example.com/b"
+
+	resolveCount := atomic.Int64{}
+	r := &mockResolver{
+		name:      "test",
+		canHandle: func(url string) bool { return url == url1 || url == url2 },
+		resolve: func(_ context.Context, url string) (models.FullItem, error) {
+			resolveCount.Add(1)
+			item := makeResolvedItem("resolved", url)
+			if url == url1 {
+				item.SetLinks([]models.Link{{URL: url2}})
+			}
+			return item, nil
+		},
+	}
+
+	engine := NewEngine([]interfaces.Resolver{r})
+	items := []models.FullItem{makeItem("start", url1)}
+
+	// MaxDepth: 0 should be treated as 1.
+	_, err := engine.Resolve(context.Background(), items, Config{MaxDepth: 0})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resolveCount.Load() != 1 {
+		t.Errorf("MaxDepth=0 should behave as depth=1, got %d resolve calls", resolveCount.Load())
+	}
+}
+
+func TestEngine_CrossRefMetadata(t *testing.T) {
+	const targetURL = "https://docs.google.com/document/d/xyz"
+
+	r := &mockResolver{
+		name:      "drive",
+		canHandle: func(url string) bool { return url == targetURL },
+		resolve: func(_ context.Context, url string) (models.FullItem, error) {
+			return makeResolvedItem("drive_xyz", url), nil
+		},
+	}
+
+	engine := NewEngine([]interfaces.Resolver{r})
+	original := makeItem("slack-msg", targetURL)
+	original.SetMetadata(map[string]interface{}{})
+
+	result, err := engine.Resolve(context.Background(), []models.FullItem{original}, Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(result))
+	}
+
+	// The original item should have resolved_refs set.
+	origMeta := result[0].GetMetadata()
+	refs, ok := origMeta["resolved_refs"].([]string)
+
+	if !ok || len(refs) == 0 {
+		t.Errorf("original item missing resolved_refs metadata, got: %v", origMeta["resolved_refs"])
+	}
+
+	// The resolved item should have referenced_by set.
+	resolvedMeta := result[1].GetMetadata()
+	refBy, ok := resolvedMeta["referenced_by"].([]string)
+
+	if !ok || len(refBy) == 0 {
+		t.Errorf("resolved item missing referenced_by metadata, got: %v", resolvedMeta["referenced_by"])
+	}
+}
+
+func TestEngine_ResolverError(t *testing.T) {
+	const targetURL = "https://example.com/fail"
+
+	r := &mockResolver{
+		name:      "failing",
+		canHandle: func(url string) bool { return url == targetURL },
+		resolve: func(_ context.Context, url string) (models.FullItem, error) {
+			return nil, errors.New("network error")
+		},
+	}
+
+	engine := NewEngine([]interfaces.Resolver{r})
+	items := []models.FullItem{makeItem("a", targetURL)}
+
+	// Errors from individual resolvers must not propagate as fatal.
+	result, err := engine.Resolve(context.Background(), items, Config{})
+	if err != nil {
+		t.Fatalf("resolver error should be non-fatal, got: %v", err)
+	}
+
+	// Only the original item; nothing resolved due to error.
+	if len(result) != 1 {
+		t.Errorf("expected 1 item (original only), got %d", len(result))
+	}
+}
+
+func TestEngine_FreshnessSkip(t *testing.T) {
+	const targetURL = "https://example.com/fresh"
+
+	r := &mockResolver{
+		name:      "fresh",
+		canHandle: func(url string) bool { return url == targetURL },
+		// Returning (nil, nil) signals "skip this item".
+		resolve: func(_ context.Context, url string) (models.FullItem, error) {
+			return nil, nil
+		},
+	}
+
+	engine := NewEngine([]interfaces.Resolver{r})
+	items := []models.FullItem{makeItem("a", targetURL)}
+
+	result, err := engine.Resolve(context.Background(), items, Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Errorf("freshness skip should produce no new item, got %d items", len(result))
+	}
+}
+
+func TestEngine_OriginalItemsAlwaysIncluded(t *testing.T) {
+	engine := NewEngine(nil)
+	items := []models.FullItem{
+		makeItem("a", ""),
+		makeItem("b", ""),
+	}
+
+	result, err := engine.Resolve(context.Background(), items, Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Errorf("original items must always be in result, got %d", len(result))
+	}
+}
+
+func TestEngine_FirstResolverWins(t *testing.T) {
+	const targetURL = "https://example.com/item"
+
+	calls := []string{}
+
+	r1 := &mockResolver{
+		name:      "first",
+		canHandle: func(url string) bool { return true },
+		resolve: func(_ context.Context, url string) (models.FullItem, error) {
+			calls = append(calls, "first")
+			return makeResolvedItem("from-first", url), nil
+		},
+	}
+
+	r2 := &mockResolver{
+		name:      "second",
+		canHandle: func(url string) bool { return true },
+		resolve: func(_ context.Context, url string) (models.FullItem, error) {
+			calls = append(calls, "second")
+			return makeResolvedItem("from-second", url), nil
+		},
+	}
+
+	engine := NewEngine([]interfaces.Resolver{r1, r2})
+	items := []models.FullItem{makeItem("a", targetURL)}
+
+	_, err := engine.Resolve(context.Background(), items, Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(calls) != 1 || calls[0] != "first" {
+		t.Errorf("only the first matching resolver should be called, got: %v", calls)
+	}
+}
+
+// Ensure Engine works correctly with a zero-value time for items without links.
+func TestEngine_ItemsWithNoLinks(t *testing.T) {
+	r := &mockResolver{
+		name:      "noop",
+		canHandle: func(url string) bool { return true },
+		resolve: func(_ context.Context, url string) (models.FullItem, error) {
+			return makeResolvedItem("resolved", url), nil
+		},
+	}
+
+	engine := NewEngine([]interfaces.Resolver{r})
+
+	item := models.NewBasicItem("no-links", "No Links")
+	item.SetLinks(nil)
+	item.SetMetadata(map[string]interface{}{})
+	item.SetCreatedAt(time.Now())
+
+	result, err := engine.Resolve(context.Background(), []models.FullItem{item}, Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Errorf("item with no links should pass through unchanged, got %d items", len(result))
+	}
+
+	if r.calls.Load() != 0 {
+		t.Errorf("resolver should not be called for items with no links")
+	}
+}

--- a/internal/resolve/engine_test.go
+++ b/internal/resolve/engine_test.go
@@ -258,12 +258,16 @@ func TestEngine_CrossRefMetadata(t *testing.T) {
 		t.Errorf("original item missing resolved_refs metadata, got: %v", origMeta["resolved_refs"])
 	}
 
-	// The resolved item should have referenced_by set.
+	// The resolved item should have referenced_by set to the referring item's ID.
 	resolvedMeta := result[1].GetMetadata()
 	refBy, ok := resolvedMeta["referenced_by"].([]string)
 
 	if !ok || len(refBy) == 0 {
 		t.Errorf("resolved item missing referenced_by metadata, got: %v", resolvedMeta["referenced_by"])
+	}
+
+	if len(refBy) > 0 && refBy[0] != original.GetID() {
+		t.Errorf("referenced_by[0] = %q, want referrer ID %q", refBy[0], original.GetID())
 	}
 }
 

--- a/internal/resolve/engine_test.go
+++ b/internal/resolve/engine_test.go
@@ -28,6 +28,7 @@ func (m *mockResolver) CanResolve(url string) bool {
 
 func (m *mockResolver) Resolve(ctx context.Context, url string) (models.FullItem, error) {
 	m.calls.Add(1)
+
 	return m.resolve(ctx, url)
 }
 
@@ -132,6 +133,7 @@ func TestEngine_DeduplicatesURLs(t *testing.T) {
 func TestEngine_DepthLimit(t *testing.T) {
 	// depth-1 URL resolves to an item that itself links to depth-2 URL
 	const url1 = "https://jira.example.com/browse/PROJ-1"
+
 	const url2 = "https://jira.example.com/browse/PROJ-2"
 
 	resolveCount := atomic.Int64{}
@@ -140,10 +142,12 @@ func TestEngine_DepthLimit(t *testing.T) {
 		canHandle: func(url string) bool { return url == url1 || url == url2 },
 		resolve: func(_ context.Context, url string) (models.FullItem, error) {
 			resolveCount.Add(1)
+
 			if url == url1 {
 				// The resolved item itself links to url2.
 				item := makeResolvedItem("issue-1", url1)
 				item.SetLinks([]models.Link{{URL: url2, Type: "external"}})
+
 				return item, nil
 			}
 
@@ -189,6 +193,7 @@ func TestEngine_DepthLimit(t *testing.T) {
 
 func TestEngine_DefaultDepthIsOne(t *testing.T) {
 	const url1 = "https://example.com/a"
+
 	const url2 = "https://example.com/b"
 
 	resolveCount := atomic.Int64{}
@@ -197,10 +202,12 @@ func TestEngine_DefaultDepthIsOne(t *testing.T) {
 		canHandle: func(url string) bool { return url == url1 || url == url2 },
 		resolve: func(_ context.Context, url string) (models.FullItem, error) {
 			resolveCount.Add(1)
+
 			item := makeResolvedItem("resolved", url)
 			if url == url1 {
 				item.SetLinks([]models.Link{{URL: url2}})
 			}
+
 			return item, nil
 		},
 	}

--- a/internal/resolve/jira_resolver.go
+++ b/internal/resolve/jira_resolver.go
@@ -44,7 +44,9 @@ func NewJiraResolver(fetcher jiraFetcher, instanceURL string) (*JiraResolver, er
 func (r *JiraResolver) Name() string { return "jira" }
 
 // CanResolve implements interfaces.Resolver. Returns true for URLs on the
-// configured Jira instance that contain a /browse/<ISSUE-KEY> path segment.
+// configured Jira instance whose path is exactly /browse/<ISSUE-KEY>.
+// Only the segment immediately after "/browse/" is validated against the
+// issue key regex to avoid false positives from longer paths.
 func (r *JiraResolver) CanResolve(rawURL string) bool {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
@@ -55,8 +57,32 @@ func (r *JiraResolver) CanResolve(rawURL string) bool {
 		return false
 	}
 
-	return strings.Contains(parsed.Path, "/browse/") &&
-		issueKeyRe.MatchString(parsed.Path)
+	segment, ok := browseSegment(parsed.Path)
+	if !ok {
+		return false
+	}
+
+	return issueKeyRe.MatchString(segment)
+}
+
+// browseSegment extracts the path segment immediately after "/browse/".
+// Returns ("", false) if the path does not contain "/browse/".
+func browseSegment(path string) (string, bool) {
+	const prefix = "/browse/"
+
+	idx := strings.Index(path, prefix)
+	if idx < 0 {
+		return "", false
+	}
+
+	segment := path[idx+len(prefix):]
+
+	// Trim any trailing path components (e.g. /edit, /comment).
+	if slash := strings.IndexByte(segment, '/'); slash >= 0 {
+		segment = segment[:slash]
+	}
+
+	return segment, true
 }
 
 // Resolve implements interfaces.Resolver.

--- a/internal/resolve/jira_resolver.go
+++ b/internal/resolve/jira_resolver.go
@@ -16,8 +16,9 @@ type jiraFetcher interface {
 	FetchIssue(ctx context.Context, issueKey string) (models.FullItem, error)
 }
 
-// issueKeyRe matches standard Jira issue keys like PROJ-123 or MY-PROJ-42.
-var issueKeyRe = regexp.MustCompile(`[A-Z][A-Z0-9]+-\d+`)
+// issueKeyRe matches standard Jira issue keys like PROJ-123, MY-PROJ-42, or A-1.
+// Single-letter project keys are supported by some Jira instances.
+var issueKeyRe = regexp.MustCompile(`[A-Z][A-Z0-9]*-\d+`)
 
 // JiraResolver resolves Jira issue URLs to FullItems.
 type JiraResolver struct {

--- a/internal/resolve/jira_resolver.go
+++ b/internal/resolve/jira_resolver.go
@@ -1,0 +1,92 @@
+package resolve
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"pkm-sync/pkg/models"
+)
+
+// jiraFetcher is the subset of JiraSource used by JiraResolver.
+// Defined as an interface so tests can inject a mock without a live Jira API.
+type jiraFetcher interface {
+	FetchIssue(ctx context.Context, issueKey string) (models.FullItem, error)
+}
+
+// issueKeyRe matches standard Jira issue keys like PROJ-123 or MY-PROJ-42.
+var issueKeyRe = regexp.MustCompile(`[A-Z][A-Z0-9]+-\d+`)
+
+// JiraResolver resolves Jira issue URLs to FullItems.
+type JiraResolver struct {
+	fetcher  jiraFetcher
+	baseHost string // lowercased host of the Jira instance, e.g. "company.atlassian.net"
+}
+
+// NewJiraResolver creates a JiraResolver for the given Jira instance URL and source.
+// instanceURL should be the full base URL, e.g. "https://company.atlassian.net".
+func NewJiraResolver(fetcher jiraFetcher, instanceURL string) (*JiraResolver, error) {
+	parsed, err := url.Parse(instanceURL)
+	if err != nil {
+		return nil, fmt.Errorf("jira resolver: invalid instance URL %q: %w", instanceURL, err)
+	}
+
+	return &JiraResolver{
+		fetcher:  fetcher,
+		baseHost: strings.ToLower(parsed.Host),
+	}, nil
+}
+
+// Name implements interfaces.Resolver.
+func (r *JiraResolver) Name() string { return "jira" }
+
+// CanResolve implements interfaces.Resolver. Returns true for URLs on the
+// configured Jira instance that contain a /browse/<ISSUE-KEY> path segment.
+func (r *JiraResolver) CanResolve(rawURL string) bool {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+
+	if strings.ToLower(parsed.Host) != r.baseHost {
+		return false
+	}
+
+	return strings.Contains(parsed.Path, "/browse/") &&
+		issueKeyRe.MatchString(parsed.Path)
+}
+
+// Resolve implements interfaces.Resolver.
+func (r *JiraResolver) Resolve(ctx context.Context, rawURL string) (models.FullItem, error) {
+	key, err := extractIssueKey(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("jira resolver: %w", err)
+	}
+
+	item, err := r.fetcher.FetchIssue(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("jira resolver: fetch %s: %w", key, err)
+	}
+
+	// Tag as resolved so sinks can distinguish it from directly-synced items.
+	item.SetTags(append(item.GetTags(), "resolved"))
+
+	return item, nil
+}
+
+// extractIssueKey pulls the Jira issue key out of a /browse/<KEY> URL path.
+func extractIssueKey(rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL %q: %w", rawURL, err)
+	}
+
+	key := issueKeyRe.FindString(parsed.Path)
+	if key == "" {
+		return "", fmt.Errorf("no issue key found in URL %q", rawURL)
+	}
+
+	return key, nil
+}

--- a/internal/resolve/jira_resolver.go
+++ b/internal/resolve/jira_resolver.go
@@ -103,14 +103,20 @@ func (r *JiraResolver) Resolve(ctx context.Context, rawURL string) (models.FullI
 	return item, nil
 }
 
-// extractIssueKey pulls the Jira issue key out of a /browse/<KEY> URL path.
+// extractIssueKey pulls the Jira issue key from the /browse/<KEY> segment of rawURL.
+// Mirrors browseSegment so extraction is consistent with CanResolve validation.
 func extractIssueKey(rawURL string) (string, error) {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return "", fmt.Errorf("invalid URL %q: %w", rawURL, err)
 	}
 
-	key := issueKeyRe.FindString(parsed.Path)
+	segment, ok := browseSegment(parsed.Path)
+	if !ok {
+		return "", fmt.Errorf("no /browse/ segment in URL %q", rawURL)
+	}
+
+	key := issueKeyRe.FindString(segment)
 	if key == "" {
 		return "", fmt.Errorf("no issue key found in URL %q", rawURL)
 	}

--- a/internal/resolve/jira_resolver_test.go
+++ b/internal/resolve/jira_resolver_test.go
@@ -32,10 +32,12 @@ func TestJiraResolver_CanResolve(t *testing.T) {
 	}{
 		{"https://company.atlassian.net/browse/PROJ-123", true},
 		{"https://company.atlassian.net/browse/MY-42", true},
-		{"https://COMPANY.ATLASSIAN.NET/browse/PROJ-1", true},        // case-insensitive host
-		{"https://other.atlassian.net/browse/PROJ-123", false},       // wrong host
-		{"https://company.atlassian.net/issues/PROJ-123", false},     // no /browse/
-		{"https://company.atlassian.net/browse/not-an-issue", false}, // no valid key
+		{"https://COMPANY.ATLASSIAN.NET/browse/PROJ-1", true},               // case-insensitive host
+		{"https://other.atlassian.net/browse/PROJ-123", false},              // wrong host
+		{"https://company.atlassian.net/issues/PROJ-123", false},            // no /browse/
+		{"https://company.atlassian.net/browse/not-an-issue", false},        // no valid key
+		{"https://company.atlassian.net/browse/PROJ-123/edit", true},        // trailing path trimmed
+		{"https://company.atlassian.net/browse/PROJ-123?focusedCommentId=1", true}, // query ignored
 		{"https://slack.com/archives/C123", false},
 	}
 

--- a/internal/resolve/jira_resolver_test.go
+++ b/internal/resolve/jira_resolver_test.go
@@ -1,0 +1,157 @@
+package resolve
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"pkm-sync/pkg/models"
+)
+
+// mockJiraFetcher implements jiraFetcher for tests.
+type mockJiraFetcher struct {
+	item     models.FullItem
+	err      error
+	lastKey  string
+}
+
+func (m *mockJiraFetcher) FetchIssue(_ context.Context, key string) (models.FullItem, error) {
+	m.lastKey = key
+	return m.item, m.err
+}
+
+func TestJiraResolver_CanResolve(t *testing.T) {
+	r, err := NewJiraResolver(&mockJiraFetcher{}, "https://company.atlassian.net")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{"https://company.atlassian.net/browse/PROJ-123", true},
+		{"https://company.atlassian.net/browse/MY-42", true},
+		{"https://COMPANY.ATLASSIAN.NET/browse/PROJ-1", true}, // case-insensitive host
+		{"https://other.atlassian.net/browse/PROJ-123", false}, // wrong host
+		{"https://company.atlassian.net/issues/PROJ-123", false}, // no /browse/
+		{"https://company.atlassian.net/browse/not-an-issue", false}, // no valid key
+		{"https://slack.com/archives/C123", false},
+	}
+
+	for _, tt := range tests {
+		got := r.CanResolve(tt.url)
+		if got != tt.want {
+			t.Errorf("CanResolve(%q) = %v, want %v", tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestJiraResolver_ExtractIssueKey(t *testing.T) {
+	tests := []struct {
+		url     string
+		want    string
+		wantErr bool
+	}{
+		{"https://company.atlassian.net/browse/PROJ-123", "PROJ-123", false},
+		{"https://company.atlassian.net/browse/MY-42", "MY-42", false},
+		{"https://company.atlassian.net/browse/ABC-9999", "ABC-9999", false},
+		{"https://company.atlassian.net/browse/", "", true},
+		{"not-a-url", "", true},
+	}
+
+	for _, tt := range tests {
+		got, err := extractIssueKey(tt.url)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("extractIssueKey(%q) expected error, got nil", tt.url)
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("extractIssueKey(%q) unexpected error: %v", tt.url, err)
+			continue
+		}
+
+		if got != tt.want {
+			t.Errorf("extractIssueKey(%q) = %q, want %q", tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestJiraResolver_Resolve_CallsFetcherWithCorrectKey(t *testing.T) {
+	fetcher := &mockJiraFetcher{
+		item: models.NewBasicItem("jira_PROJ-123", "PROJ-123"),
+	}
+
+	r, err := NewJiraResolver(fetcher, "https://company.atlassian.net")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	item, err := r.Resolve(context.Background(), "https://company.atlassian.net/browse/PROJ-123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if fetcher.lastKey != "PROJ-123" {
+		t.Errorf("FetchIssue called with key %q, want %q", fetcher.lastKey, "PROJ-123")
+	}
+
+	if item == nil {
+		t.Fatal("expected a resolved item, got nil")
+	}
+}
+
+func TestJiraResolver_Resolve_FetchError(t *testing.T) {
+	fetcher := &mockJiraFetcher{err: errors.New("API error")}
+
+	r, err := NewJiraResolver(fetcher, "https://company.atlassian.net")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = r.Resolve(context.Background(), "https://company.atlassian.net/browse/PROJ-1")
+	if err == nil {
+		t.Fatal("expected error from fetch failure, got nil")
+	}
+}
+
+func TestJiraResolver_Resolve_TaggedAsResolved(t *testing.T) {
+	baseItem := models.NewBasicItem("jira_PROJ-5", "PROJ-5")
+	baseItem.SetTags([]string{"status:open"})
+
+	fetcher := &mockJiraFetcher{item: baseItem}
+
+	r, err := NewJiraResolver(fetcher, "https://company.atlassian.net")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	item, err := r.Resolve(context.Background(), "https://company.atlassian.net/browse/PROJ-5")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+
+	for _, tag := range item.GetTags() {
+		if tag == "resolved" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("resolved item should have 'resolved' tag, got: %v", item.GetTags())
+	}
+}
+
+func TestNewJiraResolver_InvalidURL(t *testing.T) {
+	_, err := NewJiraResolver(&mockJiraFetcher{}, "://bad-url")
+	if err == nil {
+		t.Fatal("expected error for invalid instance URL, got nil")
+	}
+}

--- a/internal/resolve/jira_resolver_test.go
+++ b/internal/resolve/jira_resolver_test.go
@@ -56,6 +56,7 @@ func TestJiraResolver_ExtractIssueKey(t *testing.T) {
 		{"https://company.atlassian.net/browse/PROJ-123", "PROJ-123", false},
 		{"https://company.atlassian.net/browse/MY-42", "MY-42", false},
 		{"https://company.atlassian.net/browse/ABC-9999", "ABC-9999", false},
+		{"https://company.atlassian.net/browse/A-1", "A-1", false}, // single-letter project key
 		{"https://company.atlassian.net/browse/", "", true},
 		{"not-a-url", "", true},
 	}

--- a/internal/resolve/jira_resolver_test.go
+++ b/internal/resolve/jira_resolver_test.go
@@ -10,9 +10,9 @@ import (
 
 // mockJiraFetcher implements jiraFetcher for tests.
 type mockJiraFetcher struct {
-	item     models.FullItem
-	err      error
-	lastKey  string
+	item    models.FullItem
+	err     error
+	lastKey string
 }
 
 func (m *mockJiraFetcher) FetchIssue(_ context.Context, key string) (models.FullItem, error) {
@@ -32,9 +32,9 @@ func TestJiraResolver_CanResolve(t *testing.T) {
 	}{
 		{"https://company.atlassian.net/browse/PROJ-123", true},
 		{"https://company.atlassian.net/browse/MY-42", true},
-		{"https://COMPANY.ATLASSIAN.NET/browse/PROJ-1", true}, // case-insensitive host
-		{"https://other.atlassian.net/browse/PROJ-123", false}, // wrong host
-		{"https://company.atlassian.net/issues/PROJ-123", false}, // no /browse/
+		{"https://COMPANY.ATLASSIAN.NET/browse/PROJ-1", true},        // case-insensitive host
+		{"https://other.atlassian.net/browse/PROJ-123", false},       // wrong host
+		{"https://company.atlassian.net/issues/PROJ-123", false},     // no /browse/
 		{"https://company.atlassian.net/browse/not-an-issue", false}, // no valid key
 		{"https://slack.com/archives/C123", false},
 	}
@@ -72,6 +72,7 @@ func TestJiraResolver_ExtractIssueKey(t *testing.T) {
 
 		if err != nil {
 			t.Errorf("extractIssueKey(%q) unexpected error: %v", tt.url, err)
+
 			continue
 		}
 
@@ -140,6 +141,7 @@ func TestJiraResolver_Resolve_TaggedAsResolved(t *testing.T) {
 	for _, tag := range item.GetTags() {
 		if tag == "resolved" {
 			found = true
+
 			break
 		}
 	}

--- a/internal/resolve/jira_resolver_test.go
+++ b/internal/resolve/jira_resolver_test.go
@@ -17,6 +17,7 @@ type mockJiraFetcher struct {
 
 func (m *mockJiraFetcher) FetchIssue(_ context.Context, key string) (models.FullItem, error) {
 	m.lastKey = key
+
 	return m.item, m.err
 }
 
@@ -32,11 +33,11 @@ func TestJiraResolver_CanResolve(t *testing.T) {
 	}{
 		{"https://company.atlassian.net/browse/PROJ-123", true},
 		{"https://company.atlassian.net/browse/MY-42", true},
-		{"https://COMPANY.ATLASSIAN.NET/browse/PROJ-1", true},               // case-insensitive host
-		{"https://other.atlassian.net/browse/PROJ-123", false},              // wrong host
-		{"https://company.atlassian.net/issues/PROJ-123", false},            // no /browse/
-		{"https://company.atlassian.net/browse/not-an-issue", false},        // no valid key
-		{"https://company.atlassian.net/browse/PROJ-123/edit", true},        // trailing path trimmed
+		{"https://COMPANY.ATLASSIAN.NET/browse/PROJ-1", true},                      // case-insensitive host
+		{"https://other.atlassian.net/browse/PROJ-123", false},                     // wrong host
+		{"https://company.atlassian.net/issues/PROJ-123", false},                   // no /browse/
+		{"https://company.atlassian.net/browse/not-an-issue", false},               // no valid key
+		{"https://company.atlassian.net/browse/PROJ-123/edit", true},               // trailing path trimmed
 		{"https://company.atlassian.net/browse/PROJ-123?focusedCommentId=1", true}, // query ignored
 		{"https://slack.com/archives/C123", false},
 	}

--- a/internal/sources/google/drive/service.go
+++ b/internal/sources/google/drive/service.go
@@ -2,9 +2,12 @@ package drive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -91,8 +94,10 @@ func (s *Service) executeWithRetry(fn func() (interface{}, error)) (interface{},
 				delay = 30 * time.Second
 			}
 
-			slog.Info("Retrying Drive API call", "delay", delay, "attempt", attempt+1, "max_retries", maxRetries)
-			time.Sleep(delay)
+			// Add ±50% jitter to spread out retries and avoid thundering-herd.
+			jitter := time.Duration(float64(delay) * (0.5 + rand.Float64())) //nolint:gosec
+			slog.Info("Retrying Drive API call", "delay", jitter, "attempt", attempt+1, "max_retries", maxRetries)
+			time.Sleep(jitter)
 		}
 
 		if err := s.rateLimit(); err != nil {
@@ -137,12 +142,26 @@ func (s *Service) executeWithRetry(fn func() (interface{}, error)) (interface{},
 }
 
 // isDriveTemporaryError checks if an error is likely transient and worth retrying.
+// It prefers structured error checks (context timeout, net.Error) before falling
+// back to string matching as a last resort.
 func isDriveTemporaryError(err error) bool {
 	if err == nil {
 		return false
 	}
 
+	// Structured checks first.
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+
+	// Fallback: string matching for errors that don't implement net.Error.
 	errStr := strings.ToLower(err.Error())
+
 	for _, substr := range []string{
 		"connection reset",
 		"timeout",

--- a/internal/sources/google/drive/service.go
+++ b/internal/sources/google/drive/service.go
@@ -52,7 +52,7 @@ func (s *Service) Configure(cfg models.DriveSourceConfig) {
 // rateLimit enforces the configured request delay between API calls and checks the
 // total request cap. Returns an error if the cap has been reached.
 // The mutex is released before sleeping so parallel export goroutines are not
-// serialised on the sleep duration.
+// serialized on the sleep duration.
 func (s *Service) rateLimit() error {
 	s.mu.Lock()
 
@@ -111,11 +111,13 @@ func (s *Service) executeWithRetry(fn func() (interface{}, error)) (interface{},
 			case 403, 429: // Rate limit / too many requests
 				if attempt < maxRetries-1 {
 					slog.Info("Drive rate limit, retrying", "code", googleErr.Code)
+
 					continue
 				}
 			case 500, 502, 503, 504: // Server errors
 				if attempt < maxRetries-1 {
 					slog.Info("Drive server error, retrying", "code", googleErr.Code)
+
 					continue
 				}
 			default:
@@ -196,9 +198,10 @@ func (s *Service) ExportDocAsMarkdown(fileID string, outputPath string) error {
 		return fmt.Errorf("file %s is not a Google Doc", fileID)
 	}
 
-	// Export as plain text first (closest to markdown)
+	// Export as plain text first (closest to markdown).
+	// Body is closed via defer below; bodyclose cannot trace through interface{}.
 	raw, err := s.executeWithRetry(func() (interface{}, error) {
-		return s.client.Files.Export(fileID, "text/plain").Download()
+		return s.client.Files.Export(fileID, "text/plain").Download() //nolint:bodyclose
 	})
 	if err != nil {
 		return fmt.Errorf("unable to export document: %w", err)
@@ -496,9 +499,12 @@ func GetExportMimeType(fileMimeType, format string) (string, error) {
 }
 
 // ExportDocument exports a Google Workspace document and returns the content as a ReadCloser.
+// The caller is responsible for closing the returned body.
 func (s *Service) ExportDocument(fileID, exportMimeType string) (io.ReadCloser, error) {
+	// Body ownership is transferred to the caller via the returned ReadCloser;
+	// bodyclose cannot trace through interface{}.
 	raw, err := s.executeWithRetry(func() (interface{}, error) {
-		return s.client.Files.Export(fileID, exportMimeType).Download()
+		return s.client.Files.Export(fileID, exportMimeType).Download() //nolint:bodyclose
 	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to export document: %w", err)
@@ -687,7 +693,11 @@ func (s *Service) ListSharedWithMe(since time.Time, opts ListFilesOptions) ([]*D
 // ExportAsString exports a Google Workspace file as a string. If convertToMarkdown is true
 // and the content is HTML, it will be converted to Markdown. maxBytes limits how many bytes
 // are read from the export response; 0 means no limit.
-func (s *Service) ExportAsString(fileID, exportMimeType string, convertToMarkdown bool, maxBytes int64) (string, error) {
+func (s *Service) ExportAsString(
+	fileID, exportMimeType string,
+	convertToMarkdown bool,
+	maxBytes int64,
+) (string, error) {
 	body, err := s.ExportDocument(fileID, exportMimeType)
 	if err != nil {
 		return "", err

--- a/internal/sources/google/drive/service.go
+++ b/internal/sources/google/drive/service.go
@@ -61,6 +61,7 @@ func (s *Service) rateLimit() error {
 
 	if s.maxRequests > 0 && s.requestCount >= s.maxRequests {
 		s.mu.Unlock()
+
 		return fmt.Errorf("drive API request cap (%d) reached", s.maxRequests)
 	}
 
@@ -132,6 +133,7 @@ func (s *Service) executeWithRetry(fn func() (interface{}, error)) (interface{},
 
 		if isDriveTemporaryError(err) && attempt < maxRetries-1 {
 			slog.Info("Drive temporary error, retrying", "error", err)
+
 			continue
 		}
 

--- a/internal/sources/google/source.go
+++ b/internal/sources/google/source.go
@@ -413,6 +413,7 @@ func (g *GoogleSource) fetchDrive(since time.Time, limit int) ([]models.FullItem
 
 	// Collect successful items and log a summary of failures.
 	items := make([]models.FullItem, 0, len(results))
+
 	var failureCount int
 
 	for _, r := range results {

--- a/internal/sources/google/source.go
+++ b/internal/sources/google/source.go
@@ -20,7 +20,12 @@ import (
 // It is defined as an interface to allow injection of test doubles.
 type driveExporter interface {
 	Configure(cfg models.DriveSourceConfig)
-	ListFilesInFolder(folderID string, since time.Time, recursive bool, opts drive.ListFilesOptions) ([]*drive.DriveFileInfo, error)
+	ListFilesInFolder(
+		folderID string,
+		since time.Time,
+		recursive bool,
+		opts drive.ListFilesOptions,
+	) ([]*drive.DriveFileInfo, error)
 	ListSharedWithMe(since time.Time, opts drive.ListFilesOptions) ([]*drive.DriveFileInfo, error)
 	ExportAsString(fileID, exportMimeType string, convertToMarkdown bool, maxBytes int64) (string, error)
 }
@@ -387,9 +392,9 @@ func (g *GoogleSource) fetchDrive(since time.Time, limit int) ([]models.FullItem
 	sem := make(chan struct{}, maxConcurrent)
 
 	for i, f := range allFiles {
-		i, f := i, f
 		eg.Go(func() error {
 			sem <- struct{}{}
+
 			defer func() { <-sem }()
 
 			item, err := g.convertDriveFile(f, cfg)
@@ -411,6 +416,7 @@ func (g *GoogleSource) fetchDrive(since time.Time, limit int) ([]models.FullItem
 	for _, r := range results {
 		if r.err != nil {
 			failureCount++
+
 			slog.Warn("Failed to convert Drive file", "file", r.name, "error", r.err)
 		} else {
 			items = append(items, r.item)

--- a/internal/sources/google/source.go
+++ b/internal/sources/google/source.go
@@ -357,14 +357,11 @@ func (g *GoogleSource) fetchDrive(since time.Time, limit int) ([]models.FullItem
 		}
 	}
 
-	// Apply limit after deduplication
-	if limit > 0 && len(allFiles) > limit {
-		allFiles = allFiles[:limit]
-	}
-
-	// Skip files that exceed the configured size limit before exporting.
+	// Apply size filter before the count limit so oversized files don't consume
+	// slots and silently reduce the number of exportable items.
 	if cfg.MaxFileSizeBytes > 0 {
 		filtered := allFiles[:0]
+
 		for _, f := range allFiles {
 			if f.Size > cfg.MaxFileSizeBytes {
 				slog.Warn("Skipping Drive file: exceeds size limit",
@@ -378,6 +375,11 @@ func (g *GoogleSource) fetchDrive(since time.Time, limit int) ([]models.FullItem
 		}
 
 		allFiles = filtered
+	}
+
+	// Apply count limit after deduplication and size filtering.
+	if limit > 0 && len(allFiles) > limit {
+		allFiles = allFiles[:limit]
 	}
 
 	// Export files, optionally in parallel.

--- a/internal/sources/google/source_test.go
+++ b/internal/sources/google/source_test.go
@@ -26,9 +26,9 @@ type mockDriveExporter struct {
 
 	// Concurrency probing: when exportDelay > 0, ExportAsString blocks for that
 	// duration so tests can observe peak in-flight calls.
-	exportDelay    time.Duration
-	inFlight       atomic.Int64
-	peakInFlight   atomic.Int64
+	exportDelay  time.Duration
+	inFlight     atomic.Int64
+	peakInFlight atomic.Int64
 }
 
 func (m *mockDriveExporter) Configure(_ models.DriveSourceConfig) {
@@ -421,9 +421,9 @@ func TestFetchDrive_ParallelExports(t *testing.T) {
 	}
 
 	mock := &mockDriveExporter{
-		listFiles:    files,
+		listFiles:     files,
 		exportContent: "content",
-		exportDelay:  20 * time.Millisecond, // enough overlap to measure peak
+		exportDelay:   20 * time.Millisecond, // enough overlap to measure peak
 	}
 	cfg := models.DriveSourceConfig{MaxConcurrentExports: maxConcurrent}
 	src := newTestGoogleDriveSource(mock, cfg)
@@ -457,9 +457,9 @@ func TestFetchDrive_SequentialWhenNotConfigured(t *testing.T) {
 	}
 
 	mock := &mockDriveExporter{
-		listFiles:    files,
+		listFiles:     files,
 		exportContent: "content",
-		exportDelay:  10 * time.Millisecond,
+		exportDelay:   10 * time.Millisecond,
 	}
 	// MaxConcurrentExports = 0 → defaults to 1 (sequential)
 	src := newTestGoogleDriveSource(mock, models.DriveSourceConfig{})

--- a/internal/sources/google/source_test.go
+++ b/internal/sources/google/source_test.go
@@ -21,8 +21,9 @@ type mockDriveExporter struct {
 	exportErr       error
 	configureCalled bool
 
-	// Recorded arguments for assertion in tests.
-	lastMaxBytes int64
+	// lastMaxBytes is written concurrently by parallel export goroutines;
+	// use atomic to avoid a data race under -race.
+	lastMaxBytes atomic.Int64
 
 	// Concurrency probing via timing (exportDelay > 0): ExportAsString sleeps
 	// briefly so goroutines can overlap. For a deterministic alternative use
@@ -31,6 +32,9 @@ type mockDriveExporter struct {
 	exportBlock  chan struct{} // when non-nil, block until closed
 	inFlight     atomic.Int64
 	peakInFlight atomic.Int64
+	// startedCount is incremented after peakInFlight is updated, before blocking.
+	// Tests can wait on startedCount >= N to guarantee N goroutines have updated peak.
+	startedCount atomic.Int64
 }
 
 func (m *mockDriveExporter) Configure(_ models.DriveSourceConfig) {
@@ -42,7 +46,7 @@ func (m *mockDriveExporter) ListFilesInFolder(_ string, _ time.Time, _ bool, _ d
 }
 
 func (m *mockDriveExporter) ExportAsString(_ string, _ string, _ bool, maxBytes int64) (string, error) {
-	m.lastMaxBytes = maxBytes
+	m.lastMaxBytes.Store(maxBytes)
 
 	current := m.inFlight.Add(1)
 	// Update peak atomically.
@@ -56,6 +60,10 @@ func (m *mockDriveExporter) ExportAsString(_ string, _ string, _ bool, maxBytes 
 			break
 		}
 	}
+
+	// Signal that this goroutine has committed its peak update.
+	// Tests waiting for startedCount >= N are guaranteed peak is up-to-date.
+	m.startedCount.Add(1)
 
 	if m.exportBlock != nil {
 		<-m.exportBlock // block until test releases
@@ -263,8 +271,8 @@ func TestConvertDriveFile_MaxBytesForwarded(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if mock.lastMaxBytes != 512 {
-		t.Errorf("ExportAsString received maxBytes=%d, want 512", mock.lastMaxBytes)
+	if mock.lastMaxBytes.Load() != 512 {
+		t.Errorf("ExportAsString received maxBytes=%d, want 512", mock.lastMaxBytes.Load())
 	}
 }
 
@@ -450,11 +458,12 @@ func TestFetchDrive_ParallelExports(t *testing.T) {
 		done <- result{items, err}
 	}()
 
-	// Wait until maxConcurrent goroutines are blocked at the barrier.
-	// This guarantees they are truly running concurrently.
+	// Wait until maxConcurrent goroutines have updated peakInFlight and are
+	// blocked at the barrier. startedCount is incremented after the peak CAS,
+	// so when startedCount >= maxConcurrent the peak read is guaranteed fresh.
 	deadline := time.After(5 * time.Second)
 
-	for mock.inFlight.Load() < int64(maxConcurrent) {
+	for mock.startedCount.Load() < int64(maxConcurrent) {
 		select {
 		case <-deadline:
 			close(block) // unblock to avoid goroutine leak
@@ -464,7 +473,7 @@ func TestFetchDrive_ParallelExports(t *testing.T) {
 		}
 	}
 
-	// Record peak while we know maxConcurrent goroutines are in-flight.
+	// Record peak — all maxConcurrent goroutines have updated it.
 	peak := mock.peakInFlight.Load()
 
 	// Release all blocked goroutines.

--- a/internal/sources/google/source_test.go
+++ b/internal/sources/google/source_test.go
@@ -2,7 +2,6 @@ package google
 
 import (
 	"errors"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -500,6 +499,3 @@ func TestFetchDrive_SharedWithMe(t *testing.T) {
 
 // Ensure mockDriveExporter satisfies driveExporter (compile-time check).
 var _ driveExporter = (*mockDriveExporter)(nil)
-
-// Ensure sync is imported (used in mockDriveExporter indirectly via atomic).
-var _ sync.Mutex

--- a/internal/sources/google/source_test.go
+++ b/internal/sources/google/source_test.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"errors"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -23,9 +24,11 @@ type mockDriveExporter struct {
 	// Recorded arguments for assertion in tests.
 	lastMaxBytes int64
 
-	// Concurrency probing: when exportDelay > 0, ExportAsString blocks for that
-	// duration so tests can observe peak in-flight calls.
+	// Concurrency probing via timing (exportDelay > 0): ExportAsString sleeps
+	// briefly so goroutines can overlap. For a deterministic alternative use
+	// exportBlock: goroutines block until the channel is closed.
 	exportDelay  time.Duration
+	exportBlock  chan struct{} // when non-nil, block until closed
 	inFlight     atomic.Int64
 	peakInFlight atomic.Int64
 }
@@ -38,32 +41,35 @@ func (m *mockDriveExporter) ListFilesInFolder(_ string, _ time.Time, _ bool, _ d
 	return m.listFiles, m.listErr
 }
 
-func (m *mockDriveExporter) ListSharedWithMe(_ time.Time, _ drive.ListFilesOptions) ([]*drive.DriveFileInfo, error) {
-	return m.sharedFiles, m.sharedErr
-}
-
 func (m *mockDriveExporter) ExportAsString(_ string, _ string, _ bool, maxBytes int64) (string, error) {
 	m.lastMaxBytes = maxBytes
 
-	if m.exportDelay > 0 {
-		current := m.inFlight.Add(1)
-		// Update peak if current exceeds it.
-		for {
-			peak := m.peakInFlight.Load()
-			if current <= peak {
-				break
-			}
-
-			if m.peakInFlight.CompareAndSwap(peak, current) {
-				break
-			}
+	current := m.inFlight.Add(1)
+	// Update peak atomically.
+	for {
+		peak := m.peakInFlight.Load()
+		if current <= peak {
+			break
 		}
 
-		time.Sleep(m.exportDelay)
-		m.inFlight.Add(-1)
+		if m.peakInFlight.CompareAndSwap(peak, current) {
+			break
+		}
 	}
 
+	if m.exportBlock != nil {
+		<-m.exportBlock // block until test releases
+	} else if m.exportDelay > 0 {
+		time.Sleep(m.exportDelay)
+	}
+
+	m.inFlight.Add(-1)
+
 	return m.exportContent, m.exportErr
+}
+
+func (m *mockDriveExporter) ListSharedWithMe(_ time.Time, _ drive.ListFilesOptions) ([]*drive.DriveFileInfo, error) {
+	return m.sharedFiles, m.sharedErr
 }
 
 // newTestGoogleDriveSource creates a GoogleSource wired for Drive with the given mock.
@@ -404,8 +410,9 @@ func TestFetchDrive_ListError(t *testing.T) {
 }
 
 // TestFetchDrive_ParallelExports verifies that MaxConcurrentExports controls real
-// concurrency. Each ExportAsString call blocks briefly so goroutines overlap; the
-// test asserts that peak in-flight calls is >1 and ≤ MaxConcurrentExports.
+// concurrency. Uses a channel barrier so goroutines are held until maxConcurrent
+// are provably in-flight simultaneously, making the assertion deterministic on
+// any scheduler/GOMAXPROCS configuration.
 func TestFetchDrive_ParallelExports(t *testing.T) {
 	const numFiles = 6
 
@@ -420,29 +427,63 @@ func TestFetchDrive_ParallelExports(t *testing.T) {
 		}
 	}
 
+	// exportBlock holds each goroutine until the test releases them.
+	block := make(chan struct{})
 	mock := &mockDriveExporter{
 		listFiles:     files,
 		exportContent: "content",
-		exportDelay:   20 * time.Millisecond, // enough overlap to measure peak
+		exportBlock:   block,
 	}
 	cfg := models.DriveSourceConfig{MaxConcurrentExports: maxConcurrent}
 	src := newTestGoogleDriveSource(mock, cfg)
 
-	items, err := src.fetchDrive(time.Now(), 0)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	// Run fetchDrive in a background goroutine.
+	type result struct {
+		items []models.FullItem
+		err   error
 	}
 
-	if len(items) != numFiles {
-		t.Errorf("expected %d items, got %d", numFiles, len(items))
+	done := make(chan result, 1)
+
+	go func() {
+		items, err := src.fetchDrive(time.Now(), 0)
+		done <- result{items, err}
+	}()
+
+	// Wait until maxConcurrent goroutines are blocked at the barrier.
+	// This guarantees they are truly running concurrently.
+	deadline := time.After(5 * time.Second)
+
+	for mock.inFlight.Load() < int64(maxConcurrent) {
+		select {
+		case <-deadline:
+			close(block) // unblock to avoid goroutine leak
+			t.Fatal("timed out waiting for concurrent goroutines")
+		default:
+			runtime.Gosched()
+		}
 	}
 
+	// Record peak while we know maxConcurrent goroutines are in-flight.
 	peak := mock.peakInFlight.Load()
-	if peak <= 1 {
-		t.Errorf("peak in-flight = %d, want >1 (exports should run concurrently)", peak)
+
+	// Release all blocked goroutines.
+	close(block)
+
+	res := <-done
+	if res.err != nil {
+		t.Fatalf("unexpected error: %v", res.err)
 	}
 
-	if peak > maxConcurrent {
+	if len(res.items) != numFiles {
+		t.Errorf("expected %d items, got %d", numFiles, len(res.items))
+	}
+
+	if peak < int64(maxConcurrent) {
+		t.Errorf("peak in-flight = %d, want >=%d (goroutines should be concurrent)", peak, maxConcurrent)
+	}
+
+	if peak > int64(maxConcurrent) {
 		t.Errorf("peak in-flight = %d, exceeds MaxConcurrentExports=%d", peak, maxConcurrent)
 	}
 }

--- a/internal/sources/google/source_test.go
+++ b/internal/sources/google/source_test.go
@@ -408,6 +408,7 @@ func TestFetchDrive_ListError(t *testing.T) {
 // test asserts that peak in-flight calls is >1 and ≤ MaxConcurrentExports.
 func TestFetchDrive_ParallelExports(t *testing.T) {
 	const numFiles = 6
+
 	const maxConcurrent = 3
 
 	files := make([]*drive.DriveFileInfo, numFiles)

--- a/internal/sources/jira/source.go
+++ b/internal/sources/jira/source.go
@@ -132,6 +132,39 @@ func (s *JiraSource) Fetch(since time.Time, limit int) ([]models.FullItem, error
 	return allItems, nil
 }
 
+// FetchIssue retrieves a single Jira issue by key (e.g. "PROJ-123") and converts
+// it to a FullItem. Used by the cross-source reference resolver.
+func (s *JiraSource) FetchIssue(ctx context.Context, issueKey string) (models.FullItem, error) {
+	path := fmt.Sprintf("/issue/%s?fields=*all", url.PathEscape(issueKey))
+
+	res, err := s.client.Get(ctx, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("jira: fetch issue %s: %w", issueKey, err)
+	}
+
+	if res == nil {
+		return nil, fmt.Errorf("jira: empty response for issue %s", issueKey)
+	}
+
+	defer res.Body.Close() //nolint:errcheck
+
+	if res.StatusCode != http.StatusOK {
+		var errs jiraclient.Errors
+
+		_ = json.NewDecoder(res.Body).Decode(&errs)
+
+		return nil, fmt.Errorf("jira: issue %s returned %s: %s", issueKey, res.Status, errs.String())
+	}
+
+	var issue jiraclient.Issue
+
+	if err := json.NewDecoder(res.Body).Decode(&issue); err != nil {
+		return nil, fmt.Errorf("jira: decode issue %s: %w", issueKey, err)
+	}
+
+	return issueToItem(&issue, s.serverURL, s.cfg.IncludeComments), nil
+}
+
 // searchWithAllFields performs a search with fields=*all to retrieve all issue fields.
 func (s *JiraSource) searchWithAllFields(jql string, from, limit uint) (*jiraclient.SearchResult, error) {
 	path := fmt.Sprintf(

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -7,6 +7,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"pkm-sync/internal/resolve"
 	"pkm-sync/pkg/interfaces"
 	"pkm-sync/pkg/models"
 )
@@ -26,6 +27,11 @@ type MultiSyncOptions struct {
 	SourceTags   bool
 	TransformCfg models.TransformConfig
 	DryRun       bool
+
+	// ResolveRefs enables cross-source reference resolution between Transform
+	// and Sink phases. Requires the MultiSyncer to have a non-nil resolver.
+	ResolveRefs  bool
+	ResolveDepth int // 0 defaults to 1 inside the resolve engine
 }
 
 // SourceResult records the outcome of fetching a single source.
@@ -58,11 +64,18 @@ type fetchResult struct {
 // and fans out to one or more Sinks.
 type MultiSyncer struct {
 	pipeline interfaces.TransformPipeline
+	resolver *resolve.Engine
 }
 
 // NewMultiSyncer creates a MultiSyncer. pipeline may be nil to skip transformation.
 func NewMultiSyncer(pipeline interfaces.TransformPipeline) *MultiSyncer {
 	return &MultiSyncer{pipeline: pipeline}
+}
+
+// NewMultiSyncerWithResolver creates a MultiSyncer with an optional reference
+// resolver that runs between the Transform and Sink phases.
+func NewMultiSyncerWithResolver(pipeline interfaces.TransformPipeline, resolver *resolve.Engine) *MultiSyncer {
+	return &MultiSyncer{pipeline: pipeline, resolver: resolver}
 }
 
 // SyncAll executes the full Sources → Transform → Sinks pipeline.
@@ -173,6 +186,19 @@ func (m *MultiSyncer) SyncAll(
 
 		fmt.Printf("Transformed to %d items\n", len(transformed))
 		allItems = transformed
+	}
+
+	// --- Phase 2.5: Resolve cross-source references ---
+	if opts.ResolveRefs && m.resolver != nil {
+		resolved, err := m.resolver.Resolve(ctx, allItems, resolve.Config{
+			MaxDepth: opts.ResolveDepth,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("reference resolution failed: %w", err)
+		}
+
+		fmt.Printf("After resolution: %d items (was %d)\n", len(resolved), len(allItems))
+		allItems = resolved
 	}
 
 	result.Items = allItems

--- a/pkg/interfaces/resolver.go
+++ b/pkg/interfaces/resolver.go
@@ -1,0 +1,25 @@
+package interfaces
+
+import (
+	"context"
+
+	"pkm-sync/pkg/models"
+)
+
+// Resolver matches URLs from item links and fetches the referenced content as a FullItem.
+// Each implementation covers one source type (e.g. Google Drive, Jira).
+type Resolver interface {
+	// Name returns a short identifier used in logs, e.g. "drive" or "jira".
+	Name() string
+
+	// CanResolve returns true when this resolver knows how to handle rawURL.
+	// Implementations must be fast (regex/string match only, no network calls).
+	CanResolve(rawURL string) bool
+
+	// Resolve fetches the content referenced by rawURL and returns it as a FullItem.
+	// Returns (nil, nil) when the URL is valid for this resolver but the content
+	// should be skipped (e.g. a freshness check determines it is not stale).
+	// Returns a non-nil error only for unexpected failures; callers log the error
+	// and continue processing remaining URLs.
+	Resolve(ctx context.Context, rawURL string) (models.FullItem, error)
+}

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -73,6 +73,10 @@ type SyncConfig struct {
 	SubdirFormat    string `json:"subdir_format"     yaml:"subdir_format"` // "yyyy/mm", "yyyy-mm", "source", "flat"
 	MaxFileAge      string `json:"max_file_age"      yaml:"max_file_age"`  // "30d", "6m", "1y"
 	ArchiveOldFiles bool   `json:"archive_old_files" yaml:"archive_old_files"`
+
+	// Cross-source reference resolution
+	ResolveReferences bool `json:"resolve_references" yaml:"resolve_references"` // global default
+	ResolveDepth      int  `json:"resolve_depth"      yaml:"resolve_depth"`      // max depth (0 defaults to 1)
 }
 
 type SourceConfig struct {
@@ -87,6 +91,9 @@ type SourceConfig struct {
 	SyncInterval time.Duration `json:"sync_interval,omitempty" yaml:"sync_interval,omitempty"`
 	Since        string        `json:"since,omitempty"         yaml:"since,omitempty"`
 	Priority     int           `json:"priority,omitempty"      yaml:"priority,omitempty"`
+	// ResolveReferences overrides the global SyncConfig.ResolveReferences for this source.
+	// nil means inherit from the global setting.
+	ResolveReferences *bool `json:"resolve_references,omitempty" yaml:"resolve_references,omitempty"`
 
 	// Source-specific configurations
 	Google     GoogleSourceConfig     `json:"google,omitempty"     yaml:"google,omitempty"`


### PR DESCRIPTION
Closes #48

## Summary

- New `Resolver` interface (`pkg/interfaces/resolver.go`) — `CanResolve(url)` for fast pattern matching, `Resolve(ctx, url)` to fetch a `FullItem`
- **Drive resolver** matches `docs.google.com`/`drive.google.com` URLs, uses existing `ExtractFileID` + `GetFileMetadata` + `ExportAsString`
- **Jira resolver** matches `/browse/<ISSUE-KEY>` URLs on the configured instance, delegates to new `JiraSource.FetchIssue`
- **Resolve engine** (`internal/resolve/engine.go`) runs up to `resolve_depth` rounds between Transform and Sink: deduplication (URL fetched at most once), non-fatal error handling, cross-referencing metadata (`resolved_refs` on referring items, `referenced_by` on resolved items)
- **Syncer integration** — `NewMultiSyncerWithResolver` + `MultiSyncOptions.{ResolveRefs, ResolveDepth}` wire the engine between phases 2 and 3
- **Config** — `SyncConfig.{ResolveReferences, ResolveDepth}` + per-source `SourceConfig.ResolveReferences *bool` override

## Test plan

- [ ] `go test ./internal/resolve/...` — 27 tests: engine (dedup, depth, cross-ref, error handling), drive resolver (CanResolve table, MIME types, errors), jira resolver (CanResolve table, key extraction, fetch delegation)
- [ ] `go test ./internal/sync/...` — existing syncer tests unaffected
- [ ] `go test ./internal/sources/jira/...` — existing Jira tests unaffected
- [ ] Manually verify: configure `resolve_references: true` + `resolve_depth: 1`, sync a Slack source containing Jira URLs, confirm Jira issues appear in vault alongside Slack messages with cross-ref metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-source link resolution engine that auto-resolves links (Drive, Jira) and annotates items with resolution metadata
  * Per-source and global controls for reference resolution depth and enablement
  * Drive export controls: max file size and concurrent export limits

* **Bug Fixes**
  * Improved retry behavior with jittered backoff
  * Better detection of transient network errors

* **Tests**
  * Added comprehensive tests for resolvers and resolution engine
<!-- end of auto-generated comment: release notes by coderabbit.ai -->