### PR TITLE
feat: add configurable template-based formatters system

### DIFF
--- a/internal/formatters/formatters.go
+++ b/internal/formatters/formatters.go
@@ -1,0 +1,216 @@
+// Package formatters provides configurable, Go-template-based formatters for
+// PKM sink outputs.  Each formatter is defined in the configuration file and
+// referenced by name from a target's Formatters map.
+//
+// Template data
+//
+// All three template kinds (directory, filename, content) receive the same
+// [ItemData] struct as their dot value.  The following template functions are
+// available:
+//
+//   - formatDate "layout"   – format a time.Time with the given Go layout
+//   - sanitize              – sanitize a string for use in a filename
+//   - truncate N            – truncate a string to at most N runes
+package formatters
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+	"time"
+
+	"pkm-sync/internal/utils"
+	"pkm-sync/pkg/models"
+)
+
+// ItemData is the template context passed to every formatter template.
+type ItemData struct {
+	ID          string
+	Title       string
+	Content     string
+	SourceType  string
+	ItemType    string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	Tags        []string
+	Attachments []models.Attachment
+	Metadata    map[string]interface{}
+	Links       []models.Link
+}
+
+// itemDataFromFullItem converts a FullItem into an ItemData for template rendering.
+func itemDataFromFullItem(item models.FullItem) ItemData {
+	return ItemData{
+		ID:          item.GetID(),
+		Title:       item.GetTitle(),
+		Content:     item.GetContent(),
+		SourceType:  item.GetSourceType(),
+		ItemType:    item.GetItemType(),
+		CreatedAt:   item.GetCreatedAt(),
+		UpdatedAt:   item.GetUpdatedAt(),
+		Tags:        item.GetTags(),
+		Attachments: item.GetAttachments(),
+		Metadata:    item.GetMetadata(),
+		Links:       item.GetLinks(),
+	}
+}
+
+// templateFuncs returns the template.FuncMap available to all formatter templates.
+func templateFuncs() template.FuncMap {
+	return template.FuncMap{
+		// formatDate formats a time.Time value with the given Go time layout.
+		// Usage: {{.CreatedAt | formatDate "2006-01-02"}}
+		"formatDate": func(layout string, t time.Time) string {
+			return t.Format(layout)
+		},
+		// sanitize converts a string to a safe filename component.
+		// Usage: {{.Title | sanitize}}
+		"sanitize": func(s string) string {
+			return utils.SanitizeFilename(s)
+		},
+		// truncate limits a string to at most n runes.
+		// Usage: {{.Title | truncate 50}}
+		"truncate": func(n int, s string) string {
+			runes := []rune(s)
+			if len(runes) <= n {
+				return s
+			}
+			return string(runes[:n])
+		},
+	}
+}
+
+// TemplateFormatter is a formatter backed by three compiled Go templates: one
+// each for the directory path, the filename (without extension), and the full
+// file content.
+type TemplateFormatter struct {
+	name      string
+	itemType  string
+	dirTmpl   *template.Template // may be nil when DirectoryPattern is empty
+	fileTmpl  *template.Template // may be nil when FilenamePattern is empty
+	contTmpl  *template.Template // may be nil when ContentTemplate is empty
+}
+
+// New compiles a TemplateFormatter from a [models.FormatterConfig].
+// Returns an error if any non-empty template fails to parse.
+func New(cfg models.FormatterConfig) (*TemplateFormatter, error) {
+	funcs := templateFuncs()
+
+	tf := &TemplateFormatter{
+		name:     cfg.Name,
+		itemType: cfg.Type,
+	}
+
+	if p := cfg.Spec.DirectoryPattern; p != "" {
+		t, err := template.New("dir").Funcs(funcs).Parse(p)
+		if err != nil {
+			return nil, fmt.Errorf("formatter %q: directory_pattern: %w", cfg.Name, err)
+		}
+		tf.dirTmpl = t
+	}
+
+	if p := cfg.Spec.FilenamePattern; p != "" {
+		t, err := template.New("file").Funcs(funcs).Parse(p)
+		if err != nil {
+			return nil, fmt.Errorf("formatter %q: filename_pattern: %w", cfg.Name, err)
+		}
+		tf.fileTmpl = t
+	}
+
+	if p := cfg.Spec.ContentTemplate; p != "" {
+		t, err := template.New("content").Funcs(funcs).Parse(p)
+		if err != nil {
+			return nil, fmt.Errorf("formatter %q: content_template: %w", cfg.Name, err)
+		}
+		tf.contTmpl = t
+	}
+
+	return tf, nil
+}
+
+// Name returns the formatter's name as declared in the configuration.
+func (tf *TemplateFormatter) Name() string { return tf.name }
+
+// ItemType returns the item type this formatter targets (e.g. "event", "thread").
+func (tf *TemplateFormatter) ItemType() string { return tf.itemType }
+
+// HasDirectoryPattern reports whether the formatter defines a directory template.
+func (tf *TemplateFormatter) HasDirectoryPattern() bool { return tf.dirTmpl != nil }
+
+// HasFilenamePattern reports whether the formatter defines a filename template.
+func (tf *TemplateFormatter) HasFilenamePattern() bool { return tf.fileTmpl != nil }
+
+// HasContentTemplate reports whether the formatter defines a content template.
+func (tf *TemplateFormatter) HasContentTemplate() bool { return tf.contTmpl != nil }
+
+// FormatDirectory renders the directory_pattern template for the given item.
+// Returns an empty string if no template was configured.
+func (tf *TemplateFormatter) FormatDirectory(item models.FullItem) (string, error) {
+	if tf.dirTmpl == nil {
+		return "", nil
+	}
+	return tf.render(tf.dirTmpl, item)
+}
+
+// FormatFilename renders the filename_pattern template for the given item.
+// Returns an empty string if no template was configured.
+func (tf *TemplateFormatter) FormatFilename(item models.FullItem) (string, error) {
+	if tf.fileTmpl == nil {
+		return "", nil
+	}
+	return tf.render(tf.fileTmpl, item)
+}
+
+// FormatContent renders the content_template template for the given item.
+// Returns an empty string if no template was configured.
+func (tf *TemplateFormatter) FormatContent(item models.FullItem) (string, error) {
+	if tf.contTmpl == nil {
+		return "", nil
+	}
+	return tf.render(tf.contTmpl, item)
+}
+
+func (tf *TemplateFormatter) render(t *template.Template, item models.FullItem) (string, error) {
+	data := itemDataFromFullItem(item)
+
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("formatter %q: render %q: %w", tf.name, t.Name(), err)
+	}
+
+	return strings.TrimSpace(buf.String()), nil
+}
+
+// Registry maps formatter names to their compiled TemplateFormatters.
+type Registry struct {
+	byName map[string]*TemplateFormatter
+}
+
+// BuildRegistry compiles every FormatterConfig in cfgs and returns a Registry.
+// The first compilation error aborts and is returned to the caller.
+func BuildRegistry(cfgs []models.FormatterConfig) (*Registry, error) {
+	r := &Registry{byName: make(map[string]*TemplateFormatter, len(cfgs))}
+
+	for _, cfg := range cfgs {
+		tf, err := New(cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		r.byName[cfg.Name] = tf
+	}
+
+	return r, nil
+}
+
+// Lookup returns the named formatter, or (nil, false) if it does not exist.
+func (r *Registry) Lookup(name string) (*TemplateFormatter, bool) {
+	if r == nil {
+		return nil, false
+	}
+
+	tf, ok := r.byName[name]
+
+	return tf, ok
+}

--- a/internal/formatters/formatters.go
+++ b/internal/formatters/formatters.go
@@ -2,8 +2,6 @@
 // PKM sink outputs.  Each formatter is defined in the configuration file and
 // referenced by name from a target's Formatters map.
 //
-// Template data
-//
 // All three template kinds (directory, filename, content) receive the same
 // [ItemData] struct as their dot value.  The following template functions are
 // available:
@@ -76,6 +74,7 @@ func templateFuncs() template.FuncMap {
 			if len(runes) <= n {
 				return s
 			}
+
 			return string(runes[:n])
 		},
 	}
@@ -85,11 +84,11 @@ func templateFuncs() template.FuncMap {
 // each for the directory path, the filename (without extension), and the full
 // file content.
 type TemplateFormatter struct {
-	name      string
-	itemType  string
-	dirTmpl   *template.Template // may be nil when DirectoryPattern is empty
-	fileTmpl  *template.Template // may be nil when FilenamePattern is empty
-	contTmpl  *template.Template // may be nil when ContentTemplate is empty
+	name     string
+	itemType string
+	dirTmpl  *template.Template // may be nil when DirectoryPattern is empty
+	fileTmpl *template.Template // may be nil when FilenamePattern is empty
+	contTmpl *template.Template // may be nil when ContentTemplate is empty
 }
 
 // New compiles a TemplateFormatter from a [models.FormatterConfig].
@@ -107,6 +106,7 @@ func New(cfg models.FormatterConfig) (*TemplateFormatter, error) {
 		if err != nil {
 			return nil, fmt.Errorf("formatter %q: directory_pattern: %w", cfg.Name, err)
 		}
+
 		tf.dirTmpl = t
 	}
 
@@ -115,6 +115,7 @@ func New(cfg models.FormatterConfig) (*TemplateFormatter, error) {
 		if err != nil {
 			return nil, fmt.Errorf("formatter %q: filename_pattern: %w", cfg.Name, err)
 		}
+
 		tf.fileTmpl = t
 	}
 
@@ -123,6 +124,7 @@ func New(cfg models.FormatterConfig) (*TemplateFormatter, error) {
 		if err != nil {
 			return nil, fmt.Errorf("formatter %q: content_template: %w", cfg.Name, err)
 		}
+
 		tf.contTmpl = t
 	}
 
@@ -150,6 +152,7 @@ func (tf *TemplateFormatter) FormatDirectory(item models.FullItem) (string, erro
 	if tf.dirTmpl == nil {
 		return "", nil
 	}
+
 	return tf.render(tf.dirTmpl, item)
 }
 
@@ -159,6 +162,7 @@ func (tf *TemplateFormatter) FormatFilename(item models.FullItem) (string, error
 	if tf.fileTmpl == nil {
 		return "", nil
 	}
+
 	return tf.render(tf.fileTmpl, item)
 }
 
@@ -168,6 +172,7 @@ func (tf *TemplateFormatter) FormatContent(item models.FullItem) (string, error)
 	if tf.contTmpl == nil {
 		return "", nil
 	}
+
 	return tf.render(tf.contTmpl, item)
 }
 

--- a/internal/formatters/formatters.go
+++ b/internal/formatters/formatters.go
@@ -14,6 +14,7 @@ package formatters
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"strings"
 	"text/template"
 	"time"
@@ -70,6 +71,10 @@ func templateFuncs() template.FuncMap {
 		// truncate limits a string to at most n runes.
 		// Usage: {{.Title | truncate 50}}
 		"truncate": func(n int, s string) string {
+			if n <= 0 {
+				return ""
+			}
+
 			runes := []rune(s)
 			if len(runes) <= n {
 				return s
@@ -201,6 +206,10 @@ func BuildRegistry(cfgs []models.FormatterConfig) (*Registry, error) {
 		tf, err := New(cfg)
 		if err != nil {
 			return nil, err
+		}
+
+		if _, exists := r.byName[cfg.Name]; exists {
+			slog.Warn("duplicate formatter name; replacing previous entry", "name", cfg.Name)
 		}
 
 		r.byName[cfg.Name] = tf

--- a/internal/formatters/formatters_test.go
+++ b/internal/formatters/formatters_test.go
@@ -16,6 +16,7 @@ func makeItem(id, title, itemType string) models.FullItem {
 	item := models.NewBasicItem(id, title)
 	item.SetItemType(itemType)
 	item.SetCreatedAt(fixedTime)
+
 	return item
 }
 
@@ -130,6 +131,7 @@ func TestTruncateFunction(t *testing.T) {
 	}
 
 	item := makeItem("4", "Hello World", "thread")
+
 	got, err := tf.FormatFilename(item)
 	if err != nil {
 		t.Fatalf("FormatFilename: %v", err)
@@ -147,6 +149,7 @@ func TestFormatDirectory_Empty_WhenNoTemplate(t *testing.T) {
 	}
 
 	item := makeItem("5", "X", "event")
+
 	got, err := tf.FormatDirectory(item)
 	if err != nil {
 		t.Fatalf("FormatDirectory: %v", err)
@@ -200,6 +203,7 @@ func TestBuildRegistry_DuplicateName_LastWins(t *testing.T) {
 	}
 
 	item := makeItem("6", "T", "event")
+
 	got, err := tf.FormatFilename(item)
 	if err != nil {
 		t.Fatalf("FormatFilename: %v", err)
@@ -223,6 +227,7 @@ func TestBuildRegistry_InvalidTemplate_ReturnsError(t *testing.T) {
 
 func TestNilRegistry_Lookup(t *testing.T) {
 	var reg *formatters.Registry
+
 	tf, ok := reg.Lookup("anything")
 
 	if ok || tf != nil {

--- a/internal/formatters/formatters_test.go
+++ b/internal/formatters/formatters_test.go
@@ -68,6 +68,7 @@ func TestFormatDirectory(t *testing.T) {
 	}
 
 	item := makeItem("1", "Standup", "event")
+
 	got, err := tf.FormatDirectory(item)
 	if err != nil {
 		t.Fatalf("FormatDirectory: %v", err)
@@ -88,6 +89,7 @@ func TestFormatFilename(t *testing.T) {
 	}
 
 	item := makeItem("2", "Team Meeting", "event")
+
 	got, err := tf.FormatFilename(item)
 	if err != nil {
 		t.Fatalf("FormatFilename: %v", err)
@@ -108,6 +110,7 @@ Date: {{.CreatedAt | formatDate "January 2, 2006"}}`))
 	}
 
 	item := makeItem("3", "Sprint Review", "event")
+
 	got, err := tf.FormatContent(item)
 	if err != nil {
 		t.Fatalf("FormatContent: %v", err)

--- a/internal/formatters/formatters_test.go
+++ b/internal/formatters/formatters_test.go
@@ -1,0 +1,228 @@
+package formatters_test
+
+import (
+	"testing"
+	"time"
+
+	"pkm-sync/internal/formatters"
+	"pkm-sync/pkg/models"
+)
+
+// fixedTime is a stable timestamp used across tests.
+var fixedTime = time.Date(2024, 3, 15, 9, 30, 0, 0, time.UTC)
+
+// makeItem builds a minimal FullItem for testing.
+func makeItem(id, title, itemType string) models.FullItem {
+	item := models.NewBasicItem(id, title)
+	item.SetItemType(itemType)
+	item.SetCreatedAt(fixedTime)
+	return item
+}
+
+func cfg(name, typ, dir, file, content string) models.FormatterConfig {
+	return models.FormatterConfig{
+		Name: name,
+		Type: typ,
+		Spec: models.FormatterSpec{
+			DirectoryPattern: dir,
+			FilenamePattern:  file,
+			ContentTemplate:  content,
+		},
+	}
+}
+
+// --- TemplateFormatter ---
+
+func TestNew_EmptySpec(t *testing.T) {
+	tf, err := formatters.New(cfg("empty", "event", "", "", ""))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if tf.HasDirectoryPattern() {
+		t.Error("expected no directory pattern")
+	}
+
+	if tf.HasFilenamePattern() {
+		t.Error("expected no filename pattern")
+	}
+
+	if tf.HasContentTemplate() {
+		t.Error("expected no content template")
+	}
+}
+
+func TestNew_InvalidTemplate(t *testing.T) {
+	_, err := formatters.New(cfg("bad", "event", "{{.Missing}", "", ""))
+	if err == nil {
+		t.Fatal("expected parse error for invalid template, got nil")
+	}
+}
+
+func TestFormatDirectory(t *testing.T) {
+	tf, err := formatters.New(cfg("dir_test", "event",
+		`Meetings/{{.CreatedAt | formatDate "2006"}}/{{.CreatedAt | formatDate "01-January"}}`,
+		"", ""))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	item := makeItem("1", "Standup", "event")
+	got, err := tf.FormatDirectory(item)
+	if err != nil {
+		t.Fatalf("FormatDirectory: %v", err)
+	}
+
+	want := "Meetings/2024/03-March"
+	if got != want {
+		t.Errorf("FormatDirectory = %q, want %q", got, want)
+	}
+}
+
+func TestFormatFilename(t *testing.T) {
+	tf, err := formatters.New(cfg("file_test", "event", "",
+		`{{.CreatedAt | formatDate "2006-01-02"}} - {{.Title | sanitize}}`,
+		""))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	item := makeItem("2", "Team Meeting", "event")
+	got, err := tf.FormatFilename(item)
+	if err != nil {
+		t.Fatalf("FormatFilename: %v", err)
+	}
+
+	want := "2024-03-15 - Team-Meeting"
+	if got != want {
+		t.Errorf("FormatFilename = %q, want %q", got, want)
+	}
+}
+
+func TestFormatContent(t *testing.T) {
+	tf, err := formatters.New(cfg("content_test", "event", "", "",
+		`# {{.Title}}
+Date: {{.CreatedAt | formatDate "January 2, 2006"}}`))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	item := makeItem("3", "Sprint Review", "event")
+	got, err := tf.FormatContent(item)
+	if err != nil {
+		t.Fatalf("FormatContent: %v", err)
+	}
+
+	want := "# Sprint Review\nDate: March 15, 2024"
+	if got != want {
+		t.Errorf("FormatContent = %q, want %q", got, want)
+	}
+}
+
+func TestTruncateFunction(t *testing.T) {
+	tf, err := formatters.New(cfg("trunc_test", "thread", "",
+		`{{.Title | truncate 5}}`, ""))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	item := makeItem("4", "Hello World", "thread")
+	got, err := tf.FormatFilename(item)
+	if err != nil {
+		t.Fatalf("FormatFilename: %v", err)
+	}
+
+	if got != "Hello" {
+		t.Errorf("truncate(5) = %q, want %q", got, "Hello")
+	}
+}
+
+func TestFormatDirectory_Empty_WhenNoTemplate(t *testing.T) {
+	tf, err := formatters.New(cfg("nodir", "event", "", "{{.Title}}", ""))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	item := makeItem("5", "X", "event")
+	got, err := tf.FormatDirectory(item)
+	if err != nil {
+		t.Fatalf("FormatDirectory: %v", err)
+	}
+
+	if got != "" {
+		t.Errorf("expected empty dir, got %q", got)
+	}
+}
+
+// --- Registry ---
+
+func TestBuildRegistry(t *testing.T) {
+	cfgs := []models.FormatterConfig{
+		cfg("alpha", "event", "", "{{.Title}}", ""),
+		cfg("beta", "thread", `{{.CreatedAt | formatDate "2006"}}`, "", ""),
+	}
+
+	reg, err := formatters.BuildRegistry(cfgs)
+	if err != nil {
+		t.Fatalf("BuildRegistry: %v", err)
+	}
+
+	if tf, ok := reg.Lookup("alpha"); !ok || tf == nil {
+		t.Error("expected 'alpha' in registry")
+	}
+
+	if tf, ok := reg.Lookup("beta"); !ok || tf == nil {
+		t.Error("expected 'beta' in registry")
+	}
+
+	if _, ok := reg.Lookup("missing"); ok {
+		t.Error("expected 'missing' to be absent from registry")
+	}
+}
+
+func TestBuildRegistry_DuplicateName_LastWins(t *testing.T) {
+	cfgs := []models.FormatterConfig{
+		cfg("dup", "event", "", "first", ""),
+		cfg("dup", "event", "", "second", ""),
+	}
+
+	reg, err := formatters.BuildRegistry(cfgs)
+	if err != nil {
+		t.Fatalf("BuildRegistry: %v", err)
+	}
+
+	tf, ok := reg.Lookup("dup")
+	if !ok {
+		t.Fatal("expected 'dup' in registry")
+	}
+
+	item := makeItem("6", "T", "event")
+	got, err := tf.FormatFilename(item)
+	if err != nil {
+		t.Fatalf("FormatFilename: %v", err)
+	}
+
+	if got != "second" {
+		t.Errorf("expected last-registered formatter to win, got %q", got)
+	}
+}
+
+func TestBuildRegistry_InvalidTemplate_ReturnsError(t *testing.T) {
+	cfgs := []models.FormatterConfig{
+		cfg("broken", "event", "{{bad", "", ""),
+	}
+
+	_, err := formatters.BuildRegistry(cfgs)
+	if err == nil {
+		t.Fatal("expected error for invalid template")
+	}
+}
+
+func TestNilRegistry_Lookup(t *testing.T) {
+	var reg *formatters.Registry
+	tf, ok := reg.Lookup("anything")
+
+	if ok || tf != nil {
+		t.Error("nil Registry.Lookup should return (nil, false)")
+	}
+}

--- a/internal/sinks/file.go
+++ b/internal/sinks/file.go
@@ -3,6 +3,7 @@ package sinks
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -89,7 +90,15 @@ func (s *FileSink) renderItem(item models.FullItem) (dir, filename, content stri
 
 	if s.registry != nil && len(s.typeFormatters) > 0 {
 		if fmtName, ok := s.typeFormatters[item.GetItemType()]; ok {
-			tf, _ = s.registry.Lookup(fmtName)
+			var found bool
+
+			tf, found = s.registry.Lookup(fmtName)
+			if !found {
+				slog.Warn("configured formatter not found; using default",
+					"formatter", fmtName,
+					"item_type", item.GetItemType(),
+				)
+			}
 		}
 	}
 

--- a/internal/sinks/file.go
+++ b/internal/sinks/file.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time" //nolint:gci
 
+	"pkm-sync/internal/formatters"
 	"pkm-sync/pkg/interfaces"
 	"pkm-sync/pkg/models"
 )
@@ -16,6 +18,11 @@ import (
 type FileSink struct {
 	fmt       formatter
 	outputDir string
+
+	// registry holds compiled template-based formatters (may be nil).
+	registry *formatters.Registry
+	// typeFormatters maps item type (e.g. "event") to a formatter name.
+	typeFormatters map[string]string
 }
 
 // NewFileSink creates a FileSink for the given formatter name and output directory.
@@ -29,6 +36,16 @@ func NewFileSink(formatterName string, outputDir string, config map[string]any) 
 	f.configure(config)
 
 	return &FileSink{fmt: f, outputDir: outputDir}, nil
+}
+
+// WithFormatters attaches a compiled formatter registry and a type-to-name
+// mapping to the sink.  When an item's ItemType matches a key in typeMap the
+// corresponding named formatter in reg is used for directory, filename and
+// content rendering (falling back to the PKM-specific formatter for any field
+// whose template is empty).
+func (s *FileSink) WithFormatters(reg *formatters.Registry, typeMap map[string]string) {
+	s.registry = reg
+	s.typeFormatters = typeMap
 }
 
 // Name returns the name of the underlying formatter.
@@ -48,16 +65,80 @@ func (s *FileSink) Write(_ context.Context, items []models.FullItem) error {
 }
 
 func (s *FileSink) writeItem(item models.FullItem) error {
-	filename := s.fmt.formatFilename(item.GetTitle())
-	filePath := filepath.Join(s.outputDir, dateSubdirForItem(item), filename)
+	dir, filename, content, err := s.renderItem(item)
+	if err != nil {
+		return err
+	}
+
+	filePath := filepath.Join(s.outputDir, dir, filename)
 
 	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
 		return err
 	}
 
-	content := s.fmt.formatContent(item)
-
 	return os.WriteFile(filePath, []byte(content), 0644)
+}
+
+// renderItem returns the (directory, filename, content) triple for an item.
+// It applies a configured template formatter when one is registered for the
+// item's type, falling back to the built-in PKM formatter for any field whose
+// template is empty.
+func (s *FileSink) renderItem(item models.FullItem) (dir, filename, content string, err error) {
+	// Resolve the optional template formatter for this item type.
+	var tf *formatters.TemplateFormatter
+
+	if s.registry != nil && len(s.typeFormatters) > 0 {
+		if fmtName, ok := s.typeFormatters[item.GetItemType()]; ok {
+			tf, _ = s.registry.Lookup(fmtName)
+		}
+	}
+
+	// --- directory ---
+	if tf != nil && tf.HasDirectoryPattern() {
+		dir, err = tf.FormatDirectory(item)
+		if err != nil {
+			return "", "", "", fmt.Errorf("template formatter directory: %w", err)
+		}
+	} else {
+		dir = dateSubdirForItem(item)
+	}
+
+	// --- filename ---
+	if tf != nil && tf.HasFilenamePattern() {
+		filename, err = tf.FormatFilename(item)
+		if err != nil {
+			return "", "", "", fmt.Errorf("template formatter filename: %w", err)
+		}
+		// Ensure the file extension is appended if not already present.
+		if ext := s.fmt.fileExtension(); ext != "" && !hasExtension(filename, ext) {
+			filename += ext
+		}
+	} else {
+		filename = s.fmt.formatFilename(item.GetTitle())
+	}
+
+	// --- content ---
+	if tf != nil && tf.HasContentTemplate() {
+		content, err = tf.FormatContent(item)
+		if err != nil {
+			return "", "", "", fmt.Errorf("template formatter content: %w", err)
+		}
+	} else {
+		content = s.fmt.formatContent(item)
+	}
+
+	return dir, filename, content, nil
+}
+
+// hasExtension reports whether filename already ends with ext (case-insensitive).
+func hasExtension(filename, ext string) bool {
+	if len(filename) < len(ext) {
+		return false
+	}
+
+	suffix := filename[len(filename)-len(ext):]
+
+	return strings.EqualFold(suffix, ext)
 }
 
 // Preview generates a description of what files would be created/modified
@@ -66,9 +147,12 @@ func (s *FileSink) Preview(items []models.FullItem) ([]*interfaces.FilePreview, 
 	previews := make([]*interfaces.FilePreview, 0, len(items))
 
 	for _, item := range items {
-		filename := s.fmt.formatFilename(item.GetTitle())
-		filePath := filepath.Join(s.outputDir, dateSubdirForItem(item), filename)
-		content := s.fmt.formatContent(item)
+		dir, filename, content, err := s.renderItem(item)
+		if err != nil {
+			return nil, fmt.Errorf("failed to render item %s: %w", item.GetID(), err)
+		}
+
+		filePath := filepath.Join(s.outputDir, dir, filename)
 
 		action, existingContent, err := logseqDetermineFileAction(filePath, content)
 		if err != nil {

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -13,6 +13,10 @@ type Config struct {
 	// Target configurations
 	Targets map[string]TargetConfig `json:"targets" yaml:"targets"`
 
+	// Formatters defines named, template-based formatters that targets can
+	// reference by item type via TargetConfig.Formatters.
+	Formatters []FormatterConfig `json:"formatters,omitempty" yaml:"formatters,omitempty"`
+
 	// Transformer configurations
 	Transformers TransformConfig `json:"transformers" yaml:"transformers"`
 
@@ -170,11 +174,46 @@ type TargetConfig struct {
 	// Target type (output directory comes from SyncConfig.DefaultOutputDir)
 	Type string `json:"type" yaml:"type"`
 
+	// Formatters maps item type (e.g. "event", "thread") to a named formatter
+	// defined in the top-level Formatters slice.
+	Formatters map[string]string `json:"formatters,omitempty" yaml:"formatters,omitempty"`
+
 	// Obsidian-specific settings
 	Obsidian ObsidianTargetConfig `json:"obsidian,omitempty" yaml:"obsidian,omitempty"`
 
 	// Logseq-specific settings
 	Logseq LogseqTargetConfig `json:"logseq,omitempty" yaml:"logseq,omitempty"`
+}
+
+// FormatterSpec holds the Go template strings used by a configurable formatter.
+type FormatterSpec struct {
+	// DirectoryPattern is a Go template producing the sub-directory path under
+	// the sink's output root (e.g. "Meetings/{{.CreatedAt | formatDate \"2006\"}}").
+	// An empty string means "use the sink's default directory logic".
+	DirectoryPattern string `json:"directory_pattern" yaml:"directory_pattern"`
+
+	// FilenamePattern is a Go template producing the base filename without
+	// extension (e.g. "{{.CreatedAt | formatDate \"2006-01-02\"}} - {{.Title | sanitize}}").
+	// An empty string means "use the sink's default filename logic".
+	FilenamePattern string `json:"filename_pattern" yaml:"filename_pattern"`
+
+	// ContentTemplate is a Go template producing the full file content.
+	// An empty string means "use the sink's default content formatter".
+	ContentTemplate string `json:"content_template" yaml:"content_template"`
+}
+
+// FormatterConfig defines a named, type-scoped formatter backed by Go templates.
+type FormatterConfig struct {
+	// Name is the unique identifier used to reference this formatter from
+	// TargetConfig.Formatters (e.g. "meeting_obsidian").
+	Name string `json:"name" yaml:"name"`
+
+	// Type is the item type this formatter targets (e.g. "event", "thread",
+	// "issue").  It must match item.GetItemType() at runtime.
+	Type string `json:"type" yaml:"type"`
+
+	// Spec contains the template strings for directory, filename, and content.
+	Spec FormatterSpec `json:"spec" yaml:"spec"`
 }
 
 type ObsidianTargetConfig struct {


### PR DESCRIPTION
## Summary

- Adds a new `internal/formatters` package providing Go template-based formatters for PKM sink outputs
- Adds `FormatterConfig` / `FormatterSpec` structs to `pkg/models/config.go` and a `Formatters []FormatterConfig` field to `Config`
- Adds `Formatters map[string]string` to `TargetConfig` so targets can map item types to named formatters
- Updates `internal/sinks/FileSink` with `WithFormatters()` to wire the registry at construction time; per-item rendering falls back gracefully to the built-in PKM formatter for any field whose template is left empty

## Design

Users define named formatters in `config.yaml`:

```yaml
formatters:
  - name: meeting_obsidian
    type: event
    spec:
      directory_pattern: "Meetings/{{.CreatedAt | formatDate \"2006\"}}/{{.CreatedAt | formatDate \"01-January\"}}"
      filename_pattern: "{{.CreatedAt | formatDate \"2006-01-02\"}} - {{.Title | sanitize}}"
      content_template: |
        # {{.Title}}
        **Date:** {{.CreatedAt | formatDate "January 2, 2006 at 3:04 PM"}}
        {{.Content}}

targets:
  obsidian:
    type: obsidian
    formatters:
      event: meeting_obsidian
```

Available template functions: `formatDate "layout"`, `sanitize`, `truncate N`.

## Test plan

- [x] 11 unit tests in `internal/formatters/formatters_test.go` cover template compilation, rendering, all three template functions, empty-spec pass-through, registry lookup, and nil-registry safety
- [x] Existing `pkg/models` tests pass unchanged
- [x] `go vet` clean on modified packages

Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now define custom template-based formatters to control directory paths, filenames, and content generation for items
  * Formatters can be mapped to specific item types and reused across multiple targets
  * Template formatting supports custom functions for date formatting, string sanitization, and text truncation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->