### PR TITLE
feat(transform): add ContentFilterTransformer and EnhancedAutoTaggingTransformer

### DIFF
--- a/internal/transform/auto_tagging.go
+++ b/internal/transform/auto_tagging.go
@@ -1,0 +1,287 @@
+package transform
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"sort"
+	"strings"
+
+	"pkm-sync/pkg/interfaces"
+	"pkm-sync/pkg/models"
+)
+
+const transformerNameAutoTagging = "auto_tagging"
+
+// TagRule defines a single tagging rule with a pattern and the tags to apply.
+// A rule matches when its pattern (string or regex) is found in the item's content or title.
+// Priority controls evaluation order — lower numbers run first.
+type TagRule struct {
+	Pattern  string   `json:"pattern"  yaml:"pattern"`
+	Regex    string   `json:"regex"    yaml:"regex"`
+	Tags     []string `json:"tags"     yaml:"tags"`
+	Priority int      `json:"priority" yaml:"priority"`
+
+	// compiled regex (not serialized)
+	compiledRegex *regexp.Regexp
+}
+
+// EnhancedAutoTaggingTransformer automatically assigns tags based on configurable rules.
+// Rules are evaluated in ascending priority order (0 is highest).
+// Both plain-string substring matching and regular-expression matching are supported.
+// Source-type and item-type tags are optionally appended automatically.
+type EnhancedAutoTaggingTransformer struct {
+	config          map[string]interface{}
+	rules           []TagRule
+	addSourceTags   bool
+	addItemTypeTags bool
+}
+
+// NewEnhancedAutoTaggingTransformer creates a new EnhancedAutoTaggingTransformer.
+func NewEnhancedAutoTaggingTransformer() *EnhancedAutoTaggingTransformer {
+	return &EnhancedAutoTaggingTransformer{
+		config:          make(map[string]interface{}),
+		rules:           make([]TagRule, 0),
+		addSourceTags:   true,
+		addItemTypeTags: true,
+	}
+}
+
+// Name returns the transformer's registration name.
+func (t *EnhancedAutoTaggingTransformer) Name() string {
+	return transformerNameAutoTagging
+}
+
+// Configure parses the tagging configuration.
+//
+// Supported config keys:
+//
+//	rules              []map  list of tagging rules
+//	add_source_tags    bool   prepend "source:<type>" tag (default: true)
+//	add_item_type_tags bool   prepend "type:<type>" tag (default: true)
+//
+// Each rule map:
+//
+//	pattern  string   substring to match (case-insensitive)
+//	regex    string   regular expression to match against title + content
+//	tags     []string tags to apply when the rule matches
+//	priority int      evaluation order; lower = higher priority (default: 0)
+func (t *EnhancedAutoTaggingTransformer) Configure(config map[string]interface{}) error {
+	t.config = config
+	t.rules = make([]TagRule, 0)
+
+	if v, ok := config["add_source_tags"]; ok {
+		if b, ok := v.(bool); ok {
+			t.addSourceTags = b
+		}
+	}
+
+	if v, ok := config["add_item_type_tags"]; ok {
+		if b, ok := v.(bool); ok {
+			t.addItemTypeTags = b
+		}
+	}
+
+	rulesRaw, ok := config["rules"]
+	if !ok {
+		return nil
+	}
+
+	rulesSlice, ok := rulesRaw.([]interface{})
+	if !ok {
+		return fmt.Errorf("auto_tagging: 'rules' must be a list, got %T", rulesRaw)
+	}
+
+	for i, item := range rulesSlice {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			log.Printf("Warning: auto_tagging: rules[%d] must be a map, got %T — skipped", i, item)
+
+			continue
+		}
+
+		rule, err := parseTagRule(m, i)
+		if err != nil {
+			return err
+		}
+
+		t.rules = append(t.rules, rule)
+	}
+
+	// Sort rules by priority (ascending — lower number = higher priority)
+	sort.Slice(t.rules, func(i, j int) bool {
+		return t.rules[i].Priority < t.rules[j].Priority
+	})
+
+	return nil
+}
+
+// parseTagRule builds a TagRule from a raw map.
+func parseTagRule(m map[string]interface{}, idx int) (TagRule, error) {
+	rule := TagRule{}
+
+	if v, ok := m["pattern"]; ok {
+		s, ok := v.(string)
+		if !ok {
+			return rule, fmt.Errorf("auto_tagging: rules[%d].pattern must be a string, got %T", idx, v)
+		}
+
+		rule.Pattern = s
+	}
+
+	if v, ok := m["regex"]; ok {
+		s, ok := v.(string)
+		if !ok {
+			return rule, fmt.Errorf("auto_tagging: rules[%d].regex must be a string, got %T", idx, v)
+		}
+
+		re, err := regexp.Compile("(?i)" + s)
+		if err != nil {
+			return rule, fmt.Errorf("auto_tagging: rules[%d].regex invalid pattern %q: %w", idx, s, err)
+		}
+
+		rule.Regex = s
+		rule.compiledRegex = re
+	}
+
+	if rule.Pattern == "" && rule.compiledRegex == nil {
+		return rule, fmt.Errorf("auto_tagging: rules[%d] must have at least one of 'pattern' or 'regex'", idx)
+	}
+
+	if v, ok := m["tags"]; ok {
+		strs, err := toStringSlice(v, fmt.Sprintf("rules[%d].tags", idx))
+		if err != nil {
+			return rule, fmt.Errorf("auto_tagging: %w", err)
+		}
+
+		rule.Tags = strs
+	}
+
+	if v, ok := m["priority"]; ok {
+		switch n := v.(type) {
+		case int:
+			rule.Priority = n
+		case float64:
+			rule.Priority = int(n)
+		default:
+			log.Printf("Warning: auto_tagging: rules[%d].priority must be a number, got %T — using 0", idx, v)
+		}
+	}
+
+	return rule, nil
+}
+
+// Transform applies tagging rules to each item and returns items with updated tags.
+func (t *EnhancedAutoTaggingTransformer) Transform(items []models.FullItem) ([]models.FullItem, error) {
+	result := make([]models.FullItem, len(items))
+
+	for i, item := range items {
+		newTags := t.computeTags(item)
+		if len(newTags) == 0 {
+			result[i] = item
+
+			continue
+		}
+
+		result[i] = t.cloneWithTags(item, newTags)
+	}
+
+	return result, nil
+}
+
+// computeTags returns all new tags to apply to an item (deduped, excluding existing ones).
+func (t *EnhancedAutoTaggingTransformer) computeTags(item models.FullItem) []string {
+	existing := make(map[string]bool, len(item.GetTags()))
+	for _, tag := range item.GetTags() {
+		existing[tag] = true
+	}
+
+	var candidates []string
+
+	searchText := strings.ToLower(item.GetTitle() + " " + item.GetContent())
+
+	for _, rule := range t.rules {
+		if t.ruleMatchesItem(rule, searchText, item) {
+			for _, tag := range rule.Tags {
+				if !existing[tag] {
+					candidates = append(candidates, tag)
+					existing[tag] = true // prevent duplicates from multiple rules
+				}
+			}
+		}
+	}
+
+	if t.addSourceTags && item.GetSourceType() != "" {
+		tag := "source:" + item.GetSourceType()
+		if !existing[tag] {
+			candidates = append(candidates, tag)
+			existing[tag] = true
+		}
+	}
+
+	if t.addItemTypeTags && item.GetItemType() != "" {
+		tag := "type:" + item.GetItemType()
+		if !existing[tag] {
+			candidates = append(candidates, tag)
+		}
+	}
+
+	return candidates
+}
+
+// ruleMatchesItem returns true if the rule's pattern or regex matches the item.
+func (t *EnhancedAutoTaggingTransformer) ruleMatchesItem(rule TagRule, lowerText string, item models.FullItem) bool {
+	if rule.Pattern != "" {
+		if strings.Contains(lowerText, strings.ToLower(rule.Pattern)) {
+			return true
+		}
+	}
+
+	if rule.compiledRegex != nil {
+		if rule.compiledRegex.MatchString(item.GetTitle() + " " + item.GetContent()) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// cloneWithTags creates a copy of item with the additional tags merged in.
+func (t *EnhancedAutoTaggingTransformer) cloneWithTags(item models.FullItem, newTags []string) models.FullItem {
+	allTags := append(append([]string{}, item.GetTags()...), newTags...)
+
+	if thread, isThread := models.AsThread(item); isThread {
+		newThread := models.NewThread(thread.GetID(), thread.GetTitle())
+		newThread.SetContent(thread.GetContent())
+		newThread.SetSourceType(thread.GetSourceType())
+		newThread.SetItemType(thread.GetItemType())
+		newThread.SetCreatedAt(thread.GetCreatedAt())
+		newThread.SetUpdatedAt(thread.GetUpdatedAt())
+		newThread.SetAttachments(thread.GetAttachments())
+		newThread.SetMetadata(thread.GetMetadata())
+		newThread.SetLinks(thread.GetLinks())
+		newThread.SetTags(allTags)
+
+		for _, msg := range thread.GetMessages() {
+			newThread.AddMessage(msg)
+		}
+
+		return newThread
+	}
+
+	clone := models.NewBasicItem(item.GetID(), item.GetTitle())
+	clone.SetContent(item.GetContent())
+	clone.SetSourceType(item.GetSourceType())
+	clone.SetItemType(item.GetItemType())
+	clone.SetCreatedAt(item.GetCreatedAt())
+	clone.SetUpdatedAt(item.GetUpdatedAt())
+	clone.SetAttachments(item.GetAttachments())
+	clone.SetMetadata(item.GetMetadata())
+	clone.SetLinks(item.GetLinks())
+	clone.SetTags(allTags)
+
+	return clone
+}
+
+// Ensure interface compliance.
+var _ interfaces.Transformer = (*EnhancedAutoTaggingTransformer)(nil)

--- a/internal/transform/auto_tagging_test.go
+++ b/internal/transform/auto_tagging_test.go
@@ -1,0 +1,344 @@
+package transform
+
+import (
+	"testing"
+
+	"pkm-sync/pkg/models"
+)
+
+func TestEnhancedAutoTaggingTransformer_Name(t *testing.T) {
+	tr := NewEnhancedAutoTaggingTransformer()
+	if tr.Name() != "auto_tagging" {
+		t.Errorf("expected name 'auto_tagging', got %q", tr.Name())
+	}
+}
+
+func TestEnhancedAutoTaggingTransformer_NoRules(t *testing.T) {
+	tr := NewEnhancedAutoTaggingTransformer()
+	if err := tr.Configure(map[string]interface{}{}); err != nil {
+		t.Fatalf("configure error: %v", err)
+	}
+
+	item := models.NewBasicItem("1", "Hello")
+	item.SetContent("some content")
+	item.SetSourceType("gmail")
+	item.SetItemType("email")
+
+	result, err := tr.Transform([]models.FullItem{item})
+	if err != nil {
+		t.Fatalf("transform error: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(result))
+	}
+
+	// Should have source and type tags by default
+	tags := result[0].GetTags()
+	if !containsTag(tags, "source:gmail") {
+		t.Errorf("expected 'source:gmail' tag, got %v", tags)
+	}
+
+	if !containsTag(tags, "type:email") {
+		t.Errorf("expected 'type:email' tag, got %v", tags)
+	}
+}
+
+func TestEnhancedAutoTaggingTransformer_PatternRule(t *testing.T) {
+	tr := NewEnhancedAutoTaggingTransformer()
+
+	err := tr.Configure(map[string]interface{}{
+		"add_source_tags":    false,
+		"add_item_type_tags": false,
+		"rules": []interface{}{
+			map[string]interface{}{
+				"pattern": "meeting",
+				"tags":    []interface{}{"meeting", "work"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("configure error: %v", err)
+	}
+
+	item := models.NewBasicItem("1", "Weekly Meeting")
+	item.SetContent("agenda for the meeting")
+
+	result, err := tr.Transform([]models.FullItem{item})
+	if err != nil {
+		t.Fatalf("transform error: %v", err)
+	}
+
+	tags := result[0].GetTags()
+	if !containsTag(tags, "meeting") {
+		t.Errorf("expected 'meeting' tag, got %v", tags)
+	}
+
+	if !containsTag(tags, "work") {
+		t.Errorf("expected 'work' tag, got %v", tags)
+	}
+}
+
+func TestEnhancedAutoTaggingTransformer_RegexRule(t *testing.T) {
+	tr := NewEnhancedAutoTaggingTransformer()
+
+	err := tr.Configure(map[string]interface{}{
+		"add_source_tags":    false,
+		"add_item_type_tags": false,
+		"rules": []interface{}{
+			map[string]interface{}{
+				"regex": `urgent|asap|deadline`,
+				"tags":  []interface{}{"urgent", "high-priority"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("configure error: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		title    string
+		content  string
+		wantTags bool
+	}{
+		{"matches urgent", "Subject", "Please respond URGENT", true},
+		{"matches asap", "ASAP needed", "needs attention", true},
+		{"no match", "Normal email", "nothing special", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			item := models.NewBasicItem("1", tc.title)
+			item.SetContent(tc.content)
+
+			result, err := tr.Transform([]models.FullItem{item})
+			if err != nil {
+				t.Fatalf("transform error: %v", err)
+			}
+
+			tags := result[0].GetTags()
+			gotUrgent := containsTag(tags, "urgent")
+
+			if gotUrgent != tc.wantTags {
+				t.Errorf("wantTags=%v but got tags %v", tc.wantTags, tags)
+			}
+		})
+	}
+}
+
+func TestEnhancedAutoTaggingTransformer_PriorityOrdering(t *testing.T) {
+	tr := NewEnhancedAutoTaggingTransformer()
+
+	err := tr.Configure(map[string]interface{}{
+		"add_source_tags":    false,
+		"add_item_type_tags": false,
+		"rules": []interface{}{
+			// Lower priority number runs first
+			map[string]interface{}{
+				"pattern":  "urgent",
+				"tags":     []interface{}{"urgent"},
+				"priority": 2,
+			},
+			map[string]interface{}{
+				"pattern":  "meeting",
+				"tags":     []interface{}{"meeting"},
+				"priority": 1,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("configure error: %v", err)
+	}
+
+	item := models.NewBasicItem("1", "Urgent Meeting")
+	item.SetContent("this is an urgent meeting request")
+
+	result, err := tr.Transform([]models.FullItem{item})
+	if err != nil {
+		t.Fatalf("transform error: %v", err)
+	}
+
+	tags := result[0].GetTags()
+	if !containsTag(tags, "meeting") || !containsTag(tags, "urgent") {
+		t.Errorf("expected both 'meeting' and 'urgent' tags, got %v", tags)
+	}
+}
+
+func TestEnhancedAutoTaggingTransformer_NoDuplicateTags(t *testing.T) {
+	tr := NewEnhancedAutoTaggingTransformer()
+
+	err := tr.Configure(map[string]interface{}{
+		"add_source_tags":    false,
+		"add_item_type_tags": false,
+		"rules": []interface{}{
+			map[string]interface{}{
+				"pattern": "meeting",
+				"tags":    []interface{}{"work"},
+			},
+			map[string]interface{}{
+				"pattern": "urgent",
+				"tags":    []interface{}{"work", "urgent"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("configure error: %v", err)
+	}
+
+	item := models.NewBasicItem("1", "Urgent Meeting")
+	item.SetContent("urgent meeting content")
+
+	result, err := tr.Transform([]models.FullItem{item})
+	if err != nil {
+		t.Fatalf("transform error: %v", err)
+	}
+
+	tags := result[0].GetTags()
+	count := 0
+
+	for _, tag := range tags {
+		if tag == "work" {
+			count++
+		}
+	}
+
+	if count != 1 {
+		t.Errorf("expected 'work' tag exactly once, got %d occurrences in %v", count, tags)
+	}
+}
+
+func TestEnhancedAutoTaggingTransformer_PreservesExistingTags(t *testing.T) {
+	tr := NewEnhancedAutoTaggingTransformer()
+
+	err := tr.Configure(map[string]interface{}{
+		"add_source_tags":    false,
+		"add_item_type_tags": false,
+		"rules": []interface{}{
+			map[string]interface{}{
+				"pattern": "meeting",
+				"tags":    []interface{}{"meeting"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("configure error: %v", err)
+	}
+
+	item := models.NewBasicItem("1", "Meeting notes")
+	item.SetContent("agenda for meeting")
+	item.SetTags([]string{"existing-tag"})
+
+	result, err := tr.Transform([]models.FullItem{item})
+	if err != nil {
+		t.Fatalf("transform error: %v", err)
+	}
+
+	tags := result[0].GetTags()
+	if !containsTag(tags, "existing-tag") {
+		t.Errorf("expected 'existing-tag' to be preserved, got %v", tags)
+	}
+
+	if !containsTag(tags, "meeting") {
+		t.Errorf("expected 'meeting' tag, got %v", tags)
+	}
+}
+
+func TestEnhancedAutoTaggingTransformer_DisableSourceTags(t *testing.T) {
+	tr := NewEnhancedAutoTaggingTransformer()
+
+	err := tr.Configure(map[string]interface{}{
+		"add_source_tags":    false,
+		"add_item_type_tags": false,
+	})
+	if err != nil {
+		t.Fatalf("configure error: %v", err)
+	}
+
+	item := models.NewBasicItem("1", "Email")
+	item.SetSourceType("gmail")
+	item.SetItemType("email")
+
+	result, err := tr.Transform([]models.FullItem{item})
+	if err != nil {
+		t.Fatalf("transform error: %v", err)
+	}
+
+	tags := result[0].GetTags()
+	if containsTag(tags, "source:gmail") || containsTag(tags, "type:email") {
+		t.Errorf("source/type tags should be disabled, got %v", tags)
+	}
+}
+
+func TestEnhancedAutoTaggingTransformer_InvalidRegex(t *testing.T) {
+	tr := NewEnhancedAutoTaggingTransformer()
+
+	err := tr.Configure(map[string]interface{}{
+		"rules": []interface{}{
+			map[string]interface{}{
+				"regex": `[invalid`,
+				"tags":  []interface{}{"tag"},
+			},
+		},
+	})
+	if err == nil {
+		t.Error("expected configure error for invalid regex, got nil")
+	}
+}
+
+func TestEnhancedAutoTaggingTransformer_RuleMissingPatternAndRegex(t *testing.T) {
+	tr := NewEnhancedAutoTaggingTransformer()
+
+	err := tr.Configure(map[string]interface{}{
+		"rules": []interface{}{
+			map[string]interface{}{
+				"tags": []interface{}{"tag"},
+			},
+		},
+	})
+	if err == nil {
+		t.Error("expected configure error for rule without pattern or regex")
+	}
+}
+
+func TestEnhancedAutoTaggingTransformer_ThreadItem(t *testing.T) {
+	tr := NewEnhancedAutoTaggingTransformer()
+
+	err := tr.Configure(map[string]interface{}{
+		"add_source_tags":    false,
+		"add_item_type_tags": false,
+		"rules": []interface{}{
+			map[string]interface{}{
+				"pattern": "meeting",
+				"tags":    []interface{}{"meeting"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("configure error: %v", err)
+	}
+
+	thread := models.NewThread("t1", "Weekly Meeting")
+	thread.SetContent("meeting notes")
+
+	result, err := tr.Transform([]models.FullItem{thread})
+	if err != nil {
+		t.Fatalf("transform error: %v", err)
+	}
+
+	tags := result[0].GetTags()
+	if !containsTag(tags, "meeting") {
+		t.Errorf("expected 'meeting' tag on thread, got %v", tags)
+	}
+}
+
+// containsTag checks whether a string is in a slice.
+func containsTag(tags []string, target string) bool {
+	for _, tag := range tags {
+		if tag == target {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/transform/content_filter.go
+++ b/internal/transform/content_filter.go
@@ -1,0 +1,331 @@
+package transform
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"pkm-sync/pkg/interfaces"
+	"pkm-sync/pkg/models"
+)
+
+const transformerNameContentFilter = "content_filter"
+
+// FilterRule represents a single filtering rule.
+type FilterRule struct {
+	ContentContains []string `json:"content_contains" yaml:"content_contains"`
+	TitleContains   []string `json:"title_contains"   yaml:"title_contains"`
+	ContentRegex    string   `json:"content_regex"    yaml:"content_regex"`
+	TitleRegex      string   `json:"title_regex"      yaml:"title_regex"`
+	SourceTypes     []string `json:"source_types"     yaml:"source_types"`
+
+	// compiled regex (not serialized)
+	contentRegex *regexp.Regexp
+	titleRegex   *regexp.Regexp
+}
+
+// ContentFilterConfig holds the full filter transformer configuration.
+type ContentFilterConfig struct {
+	IncludeRules     []FilterRule `json:"include"            yaml:"include"`
+	ExcludeRules     []FilterRule `json:"exclude"            yaml:"exclude"`
+	MinContentLength int          `json:"min_content_length" yaml:"min_content_length"`
+}
+
+// ContentFilterTransformer filters items based on configurable include/exclude rules.
+// Items must satisfy at least one include rule (when include rules are defined) and
+// must not satisfy any exclude rule to pass through the filter.
+type ContentFilterTransformer struct {
+	config ContentFilterConfig
+	raw    map[string]interface{}
+}
+
+// NewContentFilterTransformer creates a new ContentFilterTransformer.
+func NewContentFilterTransformer() *ContentFilterTransformer {
+	return &ContentFilterTransformer{
+		raw: make(map[string]interface{}),
+	}
+}
+
+// Name returns the transformer's name for pipeline registration.
+func (t *ContentFilterTransformer) Name() string {
+	return transformerNameContentFilter
+}
+
+// Configure parses and validates the transformer configuration.
+func (t *ContentFilterTransformer) Configure(config map[string]interface{}) error {
+	t.raw = config
+
+	cfg := ContentFilterConfig{}
+
+	if v, ok := config["min_content_length"]; ok {
+		switch n := v.(type) {
+		case int:
+			cfg.MinContentLength = n
+		case float64:
+			cfg.MinContentLength = int(n)
+		default:
+			return fmt.Errorf("content_filter: min_content_length must be a number, got %T", v)
+		}
+	}
+
+	if v, ok := config["include"]; ok {
+		rules, err := parseFilterRules(v, "include")
+		if err != nil {
+			return err
+		}
+
+		cfg.IncludeRules = rules
+	}
+
+	if v, ok := config["exclude"]; ok {
+		rules, err := parseFilterRules(v, "exclude")
+		if err != nil {
+			return err
+		}
+
+		cfg.ExcludeRules = rules
+	}
+
+	t.config = cfg
+
+	return nil
+}
+
+// parseFilterRules converts raw config slice into FilterRule slice.
+func parseFilterRules(raw interface{}, field string) ([]FilterRule, error) {
+	slice, ok := raw.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("content_filter: '%s' must be a list, got %T", field, raw)
+	}
+
+	rules := make([]FilterRule, 0, len(slice))
+
+	for i, item := range slice {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("content_filter: '%s[%d]' must be a map, got %T", field, i, item)
+		}
+
+		rule, err := parseFilterRule(m, field, i)
+		if err != nil {
+			return nil, err
+		}
+
+		rules = append(rules, rule)
+	}
+
+	return rules, nil
+}
+
+// parseFilterRule converts a single raw rule map into a FilterRule.
+func parseFilterRule(m map[string]interface{}, field string, idx int) (FilterRule, error) {
+	rule := FilterRule{}
+
+	if v, ok := m["content_contains"]; ok {
+		strs, err := toStringSlice(v, fmt.Sprintf("%s[%d].content_contains", field, idx))
+		if err != nil {
+			return rule, err
+		}
+
+		rule.ContentContains = strs
+	}
+
+	if v, ok := m["title_contains"]; ok {
+		strs, err := toStringSlice(v, fmt.Sprintf("%s[%d].title_contains", field, idx))
+		if err != nil {
+			return rule, err
+		}
+
+		rule.TitleContains = strs
+	}
+
+	if v, ok := m["source_types"]; ok {
+		strs, err := toStringSlice(v, fmt.Sprintf("%s[%d].source_types", field, idx))
+		if err != nil {
+			return rule, err
+		}
+
+		rule.SourceTypes = strs
+	}
+
+	if v, ok := m["content_regex"]; ok {
+		s, ok := v.(string)
+		if !ok {
+			return rule, fmt.Errorf("content_filter: '%s[%d].content_regex' must be a string, got %T", field, idx, v)
+		}
+
+		re, err := regexp.Compile("(?i)" + s)
+		if err != nil {
+			return rule, fmt.Errorf("content_filter: '%s[%d].content_regex' invalid regex %q: %w", field, idx, s, err)
+		}
+
+		rule.ContentRegex = s
+		rule.contentRegex = re
+	}
+
+	if v, ok := m["title_regex"]; ok {
+		s, ok := v.(string)
+		if !ok {
+			return rule, fmt.Errorf("content_filter: '%s[%d].title_regex' must be a string, got %T", field, idx, v)
+		}
+
+		re, err := regexp.Compile("(?i)" + s)
+		if err != nil {
+			return rule, fmt.Errorf("content_filter: '%s[%d].title_regex' invalid regex %q: %w", field, idx, s, err)
+		}
+
+		rule.TitleRegex = s
+		rule.titleRegex = re
+	}
+
+	return rule, nil
+}
+
+// toStringSlice converts an interface{} to []string.
+func toStringSlice(v interface{}, path string) ([]string, error) {
+	slice, ok := v.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("content_filter: '%s' must be a list, got %T", path, v)
+	}
+
+	result := make([]string, 0, len(slice))
+
+	for i, elem := range slice {
+		s, ok := elem.(string)
+		if !ok {
+			return nil, fmt.Errorf("content_filter: '%s[%d]' must be a string, got %T", path, i, elem)
+		}
+
+		result = append(result, s)
+	}
+
+	return result, nil
+}
+
+// Transform filters items through include/exclude rules.
+// Semantics:
+//   - If include rules are defined, an item must match at least one.
+//   - If exclude rules are defined, an item must not match any.
+//   - If only exclude rules are defined, items that don't match any exclude rule pass.
+//   - Min content length is applied independently before rule matching.
+func (t *ContentFilterTransformer) Transform(items []models.FullItem) ([]models.FullItem, error) {
+	result := make([]models.FullItem, 0, len(items))
+
+	for _, item := range items {
+		if t.shouldInclude(item) {
+			result = append(result, item)
+		} else {
+			log.Printf("content_filter: dropped item %q (%s)", item.GetTitle(), item.GetID())
+		}
+	}
+
+	return result, nil
+}
+
+// shouldInclude returns true if an item should pass through the filter.
+func (t *ContentFilterTransformer) shouldInclude(item models.FullItem) bool {
+	// Minimum content length check
+	if t.config.MinContentLength > 0 && len(item.GetContent()) < t.config.MinContentLength {
+		return false
+	}
+
+	// Exclude rules: if any exclude rule matches, drop the item
+	for _, rule := range t.config.ExcludeRules {
+		if t.ruleMatches(rule, item) {
+			return false
+		}
+	}
+
+	// Include rules: item must match at least one (if any are defined)
+	if len(t.config.IncludeRules) > 0 {
+		for _, rule := range t.config.IncludeRules {
+			if t.ruleMatches(rule, item) {
+				return true
+			}
+		}
+
+		return false // no include rule matched
+	}
+
+	return true
+}
+
+// ruleMatches returns true when the item satisfies the rule.
+// Between conditions (content_contains, title_contains, etc.) AND semantics apply:
+// all defined conditions must match. Within a condition list (e.g. content_contains)
+// OR semantics apply: at least one keyword must match.
+func (t *ContentFilterTransformer) ruleMatches(rule FilterRule, item models.FullItem) bool {
+	title := strings.ToLower(item.GetTitle())
+	content := strings.ToLower(item.GetContent())
+
+	// content_contains: at least one keyword must appear in content (OR semantics)
+	if len(rule.ContentContains) > 0 {
+		matched := false
+
+		for _, kw := range rule.ContentContains {
+			if strings.Contains(content, strings.ToLower(kw)) {
+				matched = true
+
+				break
+			}
+		}
+
+		if !matched {
+			return false
+		}
+	}
+
+	// title_contains: at least one keyword must appear in title (OR semantics)
+	if len(rule.TitleContains) > 0 {
+		matched := false
+
+		for _, kw := range rule.TitleContains {
+			if strings.Contains(title, strings.ToLower(kw)) {
+				matched = true
+
+				break
+			}
+		}
+
+		if !matched {
+			return false
+		}
+	}
+
+	// source_types: item source type must be in the list
+	if len(rule.SourceTypes) > 0 {
+		matched := false
+
+		for _, st := range rule.SourceTypes {
+			if strings.EqualFold(item.GetSourceType(), st) {
+				matched = true
+
+				break
+			}
+		}
+
+		if !matched {
+			return false
+		}
+	}
+
+	// content_regex: must match content
+	if rule.contentRegex != nil {
+		if !rule.contentRegex.MatchString(item.GetContent()) {
+			return false
+		}
+	}
+
+	// title_regex: must match title
+	if rule.titleRegex != nil {
+		if !rule.titleRegex.MatchString(item.GetTitle()) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Ensure interface compliance.
+var _ interfaces.Transformer = (*ContentFilterTransformer)(nil)

--- a/internal/transform/content_filter_test.go
+++ b/internal/transform/content_filter_test.go
@@ -1,0 +1,312 @@
+package transform
+
+import (
+	"testing"
+
+	"pkm-sync/pkg/models"
+)
+
+func makeTestItem(id, title, content, sourceType string) models.FullItem {
+	item := models.NewBasicItem(id, title)
+	item.SetContent(content)
+	item.SetSourceType(sourceType)
+
+	return item
+}
+
+func TestContentFilterTransformer_Name(t *testing.T) {
+	tr := NewContentFilterTransformer()
+	if tr.Name() != "content_filter" {
+		t.Errorf("expected name 'content_filter', got %q", tr.Name())
+	}
+}
+
+func TestContentFilterTransformer_NoRules(t *testing.T) {
+	tr := NewContentFilterTransformer()
+	if err := tr.Configure(map[string]interface{}{}); err != nil {
+		t.Fatalf("unexpected configure error: %v", err)
+	}
+
+	items := []models.FullItem{
+		makeTestItem("1", "Hello", "world content", "gmail"),
+		makeTestItem("2", "Another", "more stuff", "slack"),
+	}
+
+	result, err := tr.Transform(items)
+	if err != nil {
+		t.Fatalf("unexpected transform error: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Errorf("expected 2 items, got %d", len(result))
+	}
+}
+
+func TestContentFilterTransformer_MinContentLength(t *testing.T) {
+	tr := NewContentFilterTransformer()
+	if err := tr.Configure(map[string]interface{}{
+		"min_content_length": 10,
+	}); err != nil {
+		t.Fatalf("configure error: %v", err)
+	}
+
+	items := []models.FullItem{
+		makeTestItem("1", "Short", "hi", "gmail"),
+		makeTestItem("2", "Long enough", "this content is long enough to pass", "gmail"),
+	}
+
+	result, err := tr.Transform(items)
+	if err != nil {
+		t.Fatalf("transform error: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Errorf("expected 1 item, got %d", len(result))
+	}
+
+	if result[0].GetID() != "2" {
+		t.Errorf("expected item id '2', got %q", result[0].GetID())
+	}
+}
+
+func TestContentFilterTransformer_ExcludeRule_ContentContains(t *testing.T) {
+	tr := NewContentFilterTransformer()
+
+	err := tr.Configure(map[string]interface{}{
+		"exclude": []interface{}{
+			map[string]interface{}{
+				"content_contains": []interface{}{"spam", "unsubscribe"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("configure error: %v", err)
+	}
+
+	items := []models.FullItem{
+		makeTestItem("1", "Normal", "normal content here", "gmail"),
+		makeTestItem("2", "Spam", "click here to unsubscribe from our list", "gmail"),
+		makeTestItem("3", "Also Spam", "this email has spam content", "gmail"),
+	}
+
+	result, err := tr.Transform(items)
+	if err != nil {
+		t.Fatalf("transform error: %v", err)
+	}
+
+	// Item 2 has "unsubscribe", item 3 has "spam" — both excluded
+	if len(result) != 1 {
+		t.Errorf("expected 1 item, got %d", len(result))
+	}
+
+	if result[0].GetID() != "1" {
+		t.Errorf("expected item '1' to pass, got %q", result[0].GetID())
+	}
+}
+
+func TestContentFilterTransformer_IncludeRule_ContentContains(t *testing.T) {
+	tr := NewContentFilterTransformer()
+
+	err := tr.Configure(map[string]interface{}{
+		"include": []interface{}{
+			map[string]interface{}{
+				"content_contains": []interface{}{"meeting"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("configure error: %v", err)
+	}
+
+	items := []models.FullItem{
+		makeTestItem("1", "Meeting notes", "attend the meeting tomorrow", "gmail"),
+		makeTestItem("2", "Random", "nothing relevant here", "gmail"),
+		makeTestItem("3", "Calendar", "weekly meeting scheduled", "calendar"),
+	}
+
+	result, err := tr.Transform(items)
+	if err != nil {
+		t.Fatalf("transform error: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Errorf("expected 2 items, got %d", len(result))
+	}
+}
+
+func TestContentFilterTransformer_IncludeAndExclude(t *testing.T) {
+	tr := NewContentFilterTransformer()
+
+	err := tr.Configure(map[string]interface{}{
+		"include": []interface{}{
+			map[string]interface{}{
+				"content_contains": []interface{}{"meeting"},
+			},
+		},
+		"exclude": []interface{}{
+			map[string]interface{}{
+				"content_contains": []interface{}{"canceled"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("configure error: %v", err)
+	}
+
+	items := []models.FullItem{
+		makeTestItem("1", "Meeting", "meeting scheduled for tomorrow", "gmail"),
+		makeTestItem("2", "No meeting", "nothing here", "gmail"),
+		makeTestItem("3", "Canceled", "meeting has been canceled", "gmail"),
+	}
+
+	result, err := tr.Transform(items)
+	if err != nil {
+		t.Fatalf("transform error: %v", err)
+	}
+
+	// Only item 1 passes: has "meeting" (include) and no "canceled" (exclude)
+	if len(result) != 1 {
+		t.Errorf("expected 1 item, got %d", len(result))
+	}
+
+	if result[0].GetID() != "1" {
+		t.Errorf("expected item '1', got %q", result[0].GetID())
+	}
+}
+
+func TestContentFilterTransformer_SourceTypeFilter(t *testing.T) {
+	tr := NewContentFilterTransformer()
+
+	err := tr.Configure(map[string]interface{}{
+		"include": []interface{}{
+			map[string]interface{}{
+				"source_types": []interface{}{"gmail"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("configure error: %v", err)
+	}
+
+	items := []models.FullItem{
+		makeTestItem("1", "Email", "from gmail", "gmail"),
+		makeTestItem("2", "Slack", "from slack", "slack"),
+		makeTestItem("3", "Drive", "from drive", "drive"),
+	}
+
+	result, err := tr.Transform(items)
+	if err != nil {
+		t.Fatalf("transform error: %v", err)
+	}
+
+	if len(result) != 1 || result[0].GetID() != "1" {
+		t.Errorf("expected only gmail item to pass, got %d items", len(result))
+	}
+}
+
+func TestContentFilterTransformer_ContentRegex(t *testing.T) {
+	tr := NewContentFilterTransformer()
+
+	err := tr.Configure(map[string]interface{}{
+		"exclude": []interface{}{
+			map[string]interface{}{
+				"content_regex": `unsubscribe|promotional`,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("configure error: %v", err)
+	}
+
+	items := []models.FullItem{
+		makeTestItem("1", "Normal", "regular content here", "gmail"),
+		makeTestItem("2", "Promo", "this is a Promotional offer", "gmail"),
+		makeTestItem("3", "Unsub", "click here to Unsubscribe", "gmail"),
+	}
+
+	result, err := tr.Transform(items)
+	if err != nil {
+		t.Fatalf("transform error: %v", err)
+	}
+
+	if len(result) != 1 || result[0].GetID() != "1" {
+		t.Errorf("expected only 'Normal' item, got %d items", len(result))
+	}
+}
+
+func TestContentFilterTransformer_InvalidRegex(t *testing.T) {
+	tr := NewContentFilterTransformer()
+
+	err := tr.Configure(map[string]interface{}{
+		"exclude": []interface{}{
+			map[string]interface{}{
+				"content_regex": `[invalid`,
+			},
+		},
+	})
+	if err == nil {
+		t.Error("expected configure error for invalid regex, got nil")
+	}
+}
+
+func TestContentFilterTransformer_TitleContains(t *testing.T) {
+	tr := NewContentFilterTransformer()
+
+	err := tr.Configure(map[string]interface{}{
+		"exclude": []interface{}{
+			map[string]interface{}{
+				"title_contains": []interface{}{"[SPAM]"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("configure error: %v", err)
+	}
+
+	items := []models.FullItem{
+		makeTestItem("1", "[SPAM] Win a prize", "click here", "gmail"),
+		makeTestItem("2", "Normal subject", "regular content", "gmail"),
+	}
+
+	result, err := tr.Transform(items)
+	if err != nil {
+		t.Fatalf("transform error: %v", err)
+	}
+
+	if len(result) != 1 || result[0].GetID() != "2" {
+		t.Errorf("expected only item '2', got %d items", len(result))
+	}
+}
+
+func TestContentFilterTransformer_MultipleIncludeRules_AnyMatches(t *testing.T) {
+	tr := NewContentFilterTransformer()
+
+	err := tr.Configure(map[string]interface{}{
+		"include": []interface{}{
+			map[string]interface{}{
+				"content_contains": []interface{}{"urgent"},
+			},
+			map[string]interface{}{
+				"source_types": []interface{}{"calendar"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("configure error: %v", err)
+	}
+
+	items := []models.FullItem{
+		makeTestItem("1", "Urgent", "this is urgent", "gmail"),
+		makeTestItem("2", "Calendar", "team meeting", "calendar"),
+		makeTestItem("3", "Normal", "nothing special", "gmail"),
+	}
+
+	result, err := tr.Transform(items)
+	if err != nil {
+		t.Fatalf("transform error: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Errorf("expected 2 items, got %d", len(result))
+	}
+}

--- a/internal/transform/examples.go
+++ b/internal/transform/examples.go
@@ -2,8 +2,6 @@ package transform
 
 import (
 	"fmt"
-	"log"
-	"strings"
 
 	"pkm-sync/pkg/interfaces"
 	"pkm-sync/pkg/models"
@@ -11,195 +9,10 @@ import (
 
 // NOTE: ContentCleanupTransformer is now implemented in content_cleanup.go
 // with enhanced HTML processing capabilities extracted from Gmail processor.
-
-// AutoTaggingTransformer automatically adds tags based on content.
-type AutoTaggingTransformer struct {
-	config map[string]interface{}
-	rules  []TaggingRule
-}
-
-type TaggingRule struct {
-	Pattern string   `json:"pattern" yaml:"pattern"`
-	Tags    []string `json:"tags"    yaml:"tags"`
-}
-
-func NewAutoTaggingTransformer() *AutoTaggingTransformer {
-	return &AutoTaggingTransformer{
-		config: make(map[string]interface{}),
-		rules:  make([]TaggingRule, 0),
-	}
-}
-
-func (t *AutoTaggingTransformer) Name() string {
-	return "auto_tagging"
-}
-
-func (t *AutoTaggingTransformer) Configure(config map[string]interface{}) error {
-	t.config = config
-
-	// Parse tagging rules from config
-	rulesInterface, exists := config["rules"]
-	if !exists {
-		return nil
-	}
-
-	rulesSlice, ok := rulesInterface.([]interface{})
-	if !ok {
-		return nil
-	}
-
-	for _, ruleInterface := range rulesSlice {
-		rule := t.parseTaggingRule(ruleInterface)
-		if rule != nil {
-			t.rules = append(t.rules, *rule)
-		}
-	}
-
-	return nil
-}
-
-func (t *AutoTaggingTransformer) parseTaggingRule(ruleInterface interface{}) *TaggingRule {
-	ruleMap, ok := ruleInterface.(map[string]interface{})
-	if !ok {
-		log.Printf("Warning: invalid tagging rule format, expected map[string]interface{}, got %T", ruleInterface)
-
-		return nil
-	}
-
-	rule := TaggingRule{}
-
-	pattern, hasPattern := ruleMap["pattern"]
-	if !hasPattern {
-		log.Printf("Warning: tagging rule missing required 'pattern' field")
-
-		return nil
-	}
-
-	patternStr, ok := pattern.(string)
-	if !ok {
-		log.Printf("Warning: tagging rule 'pattern' must be a string, got %T", pattern)
-
-		return nil
-	}
-
-	rule.Pattern = patternStr
-
-	if tagsInterface, exists := ruleMap["tags"]; exists {
-		tagsSlice, ok := tagsInterface.([]interface{})
-		if !ok {
-			log.Printf("Warning: tagging rule 'tags' must be an array, got %T", tagsInterface)
-
-			return nil
-		}
-
-		rule.Tags = make([]string, 0, len(tagsSlice))
-
-		for i, tagInterface := range tagsSlice {
-			if tag, ok := tagInterface.(string); ok {
-				rule.Tags = append(rule.Tags, tag)
-			} else {
-				log.Printf("Warning: tagging rule tag[%d] must be a string, got %T", i, tagInterface)
-			}
-		}
-	}
-
-	return &rule
-}
-
-func (t *AutoTaggingTransformer) Transform(items []models.FullItem) ([]models.FullItem, error) {
-	transformedItems := make([]models.FullItem, len(items))
-
-	for i, item := range items {
-		// Apply tagging rules directly to FullItem
-		newTags := t.applyTaggingRulesInterface(item)
-
-		if len(newTags) > 0 {
-			// Create a new item with the existing data plus new tags
-			var transformedItem models.FullItem
-
-			if thread, isThread := models.AsThread(item); isThread {
-				// Handle Thread type
-				newThread := models.NewThread(thread.GetID(), thread.GetTitle())
-				newThread.SetContent(thread.GetContent())
-				newThread.SetSourceType(thread.GetSourceType())
-				newThread.SetItemType(thread.GetItemType())
-				newThread.SetCreatedAt(thread.GetCreatedAt())
-				newThread.SetUpdatedAt(thread.GetUpdatedAt())
-				newThread.SetAttachments(thread.GetAttachments())
-				newThread.SetMetadata(thread.GetMetadata())
-				newThread.SetLinks(thread.GetLinks())
-
-				// Copy messages
-				for _, msg := range thread.GetMessages() {
-					newThread.AddMessage(msg)
-				}
-
-				transformedItem = newThread
-			} else {
-				// Handle BasicItem type
-				newBasicItem := models.NewBasicItem(item.GetID(), item.GetTitle())
-				newBasicItem.SetContent(item.GetContent())
-				newBasicItem.SetSourceType(item.GetSourceType())
-				newBasicItem.SetItemType(item.GetItemType())
-				newBasicItem.SetCreatedAt(item.GetCreatedAt())
-				newBasicItem.SetUpdatedAt(item.GetUpdatedAt())
-				newBasicItem.SetAttachments(item.GetAttachments())
-				newBasicItem.SetMetadata(item.GetMetadata())
-				newBasicItem.SetLinks(item.GetLinks())
-
-				transformedItem = newBasicItem
-			}
-
-			// Add existing tags first, then new tags (avoiding duplicates)
-			existingTags := make(map[string]bool)
-			for _, tag := range item.GetTags() {
-				existingTags[tag] = true
-			}
-
-			allTags := append([]string{}, item.GetTags()...)
-
-			for _, newTag := range newTags {
-				if !existingTags[newTag] {
-					allTags = append(allTags, newTag)
-				}
-			}
-
-			transformedItem.SetTags(allTags)
-
-			transformedItems[i] = transformedItem
-		} else {
-			// No new tags, return original item
-			transformedItems[i] = item
-		}
-	}
-
-	return transformedItems, nil
-}
-
-func (t *AutoTaggingTransformer) applyTaggingRulesInterface(item models.FullItem) []string {
-	var newTags []string
-
-	searchText := strings.ToLower(item.GetTitle() + " " + item.GetContent())
-
-	for _, rule := range t.rules {
-		if strings.Contains(searchText, strings.ToLower(rule.Pattern)) {
-			newTags = append(newTags, rule.Tags...)
-		}
-	}
-
-	// Add source-based tags
-	if item.GetSourceType() != "" {
-		newTags = append(newTags, "source:"+item.GetSourceType())
-	}
-
-	if item.GetItemType() != "" {
-		newTags = append(newTags, "type:"+item.GetItemType())
-	}
-
-	return newTags
-}
-
-// Keep the legacy method for backward compatibility (in case it's used elsewhere)
+// NOTE: AutoTaggingTransformer is now implemented in auto_tagging.go
+// as EnhancedAutoTaggingTransformer with regex and priority support.
+// NOTE: ContentFilterTransformer is now implemented in content_filter.go
+// with include/exclude rules, keyword and regex matching.
 
 // FilterTransformer filters items based on criteria.
 type FilterTransformer struct {
@@ -360,11 +173,12 @@ func GetAllExampleTransformers() []interfaces.Transformer {
 // These include the enhanced transformers extracted from Gmail processing logic.
 func GetAllContentProcessingTransformers() []interfaces.Transformer {
 	return []interfaces.Transformer{
-		NewContentCleanupTransformer(),   // Enhanced version with HTML processing from content_cleanup.go
-		NewLinkExtractionTransformer(),   // URL extraction from link_extraction.go
-		NewSignatureRemovalTransformer(), // Signature detection from signature_removal.go
-		NewThreadGroupingTransformer(),   // Thread consolidation from thread_grouping.go
-		NewAutoTaggingTransformer(),      // Existing example transformer
-		NewFilterTransformer(),           // Existing example transformer
+		NewContentCleanupTransformer(),      // Enhanced HTML processing from content_cleanup.go
+		NewLinkExtractionTransformer(),      // URL extraction from link_extraction.go
+		NewSignatureRemovalTransformer(),    // Signature detection from signature_removal.go
+		NewThreadGroupingTransformer(),      // Thread consolidation from thread_grouping.go
+		NewEnhancedAutoTaggingTransformer(), // Pattern/regex tagging from auto_tagging.go
+		NewContentFilterTransformer(),       // Include/exclude filtering from content_filter.go
+		NewFilterTransformer(),              // Legacy filter transformer
 	}
 }

--- a/internal/transform/examples_test.go
+++ b/internal/transform/examples_test.go
@@ -61,7 +61,7 @@ func TestContentCleanupTransformerConfigure(t *testing.T) {
 }
 
 func TestAutoTaggingTransformer(t *testing.T) {
-	transformer := NewAutoTaggingTransformer()
+	transformer := NewEnhancedAutoTaggingTransformer()
 
 	if transformer.Name() != "auto_tagging" {
 		t.Errorf("Expected name 'auto_tagging', got '%s'", transformer.Name())
@@ -123,7 +123,7 @@ func TestAutoTaggingTransformer(t *testing.T) {
 }
 
 func TestAutoTaggingTransformerNoDuplicates(t *testing.T) {
-	transformer := NewAutoTaggingTransformer()
+	transformer := NewEnhancedAutoTaggingTransformer()
 
 	items := []models.FullItem{
 		func() models.FullItem {
@@ -261,17 +261,19 @@ func TestFilterTransformerInvalidConfig(t *testing.T) {
 }
 
 func TestGetAllExampleTransformers(t *testing.T) {
-	// GetAllExampleTransformers now returns all 6 transformers (same as GetAllContentProcessingTransformers).
+	// GetAllExampleTransformers returns all registered transformers
+	// (content_cleanup, link_extraction, signature_removal, thread_grouping,
+	// auto_tagging, content_filter, filter).
 	transformers := GetAllExampleTransformers()
-	if len(transformers) != 6 {
-		t.Errorf("Expected 6 transformers, got %d", len(transformers))
+	if len(transformers) != 7 {
+		t.Errorf("Expected 7 transformers, got %d", len(transformers))
 	}
 }
 
 func TestGetAllContentProcessingTransformers(t *testing.T) {
 	transformers := GetAllContentProcessingTransformers()
-	if len(transformers) != 6 {
-		t.Errorf("Expected 6 content processing transformers, got %d", len(transformers))
+	if len(transformers) != 7 {
+		t.Errorf("Expected 7 content processing transformers, got %d", len(transformers))
 	}
 }
 

--- a/internal/transform/integration_test.go
+++ b/internal/transform/integration_test.go
@@ -84,7 +84,7 @@ func TestPipelineIntegrationWithSyncEngine(t *testing.T) {
 
 	// Register transformers
 	contentCleanup := NewContentCleanupTransformer()
-	autoTagging := NewAutoTaggingTransformer()
+	autoTagging := NewEnhancedAutoTaggingTransformer()
 	filter := NewFilterTransformer()
 
 	pipeline.AddTransformer(contentCleanup)


### PR DESCRIPTION
## Summary

- Add `ContentFilterTransformer` (`internal/transform/content_filter.go`) with configurable include/exclude rules supporting keyword lists (`content_contains`, `title_contains`), `source_types`, and regex patterns (`content_regex`, `title_regex`). OR semantics within keyword lists, AND between conditions in a rule, include rules use OR (any matching rule passes the item).
- Add `EnhancedAutoTaggingTransformer` (`internal/transform/auto_tagging.go`) with priority-ordered rules, plain-string pattern matching, and compiled regex matching. Automatically adds `source:<type>` and `type:<type>` tags (configurable). Deduplicates applied tags.
- Remove the basic `AutoTaggingTransformer` placeholder from `examples.go` and wire both new transformers into `GetAllContentProcessingTransformers()` (now returns 7 transformers).
- Comprehensive unit tests for both transformers (invalid regex, missing rule fields, thread items, priority ordering, no-duplicate guarantees). Updated existing tests for the new transformer count.

Closes #21

## Test plan

- [x] `go test ./internal/transform/...` passes
- [x] `golangci-lint run ./internal/transform/...` returns 0 issues
- [x] Unit tests cover: no-rules passthrough, min_content_length, include/exclude rules, regex rules, source type filtering, priority ordering, no-duplicate tags, thread items, invalid regex error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)