### PR TITLE
feat(transform): AI Content Analysis Transformer with CLI and HTTP backends

### DIFF
--- a/internal/transform/ai_analysis.go
+++ b/internal/transform/ai_analysis.go
@@ -1,0 +1,665 @@
+package transform
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+
+	"pkm-sync/pkg/interfaces"
+	"pkm-sync/pkg/models"
+)
+
+const (
+	transformerNameAIAnalysis = "ai_analysis"
+
+	// Metadata keys for AI analysis results.
+	metaKeyAISummary     = "ai_summary"
+	metaKeyAIPriority    = "ai_priority_score"
+	metaKeyAIActionItems = "ai_action_items"
+	metaKeyAITags        = "ai_tags"
+
+	defaultRetryAttempts = 3
+	defaultRetryDelay    = time.Second
+	defaultTimeout       = 30 * time.Second
+	defaultBatchSize     = 10
+)
+
+// Default prompt strings broken into variables to keep line length under the lll limit.
+var (
+	defaultPromptPrioritize = "Rate this content's importance from 0 to 1 where 1 is most urgent." +
+		" Respond with only a number: {content}"
+
+	defaultPromptExtractActions = "List action items from this content as a JSON array of strings." +
+		` Respond with only valid JSON, example: ["action 1","action 2"]. Content: {content}`
+)
+
+// AIBackend defines the interface for AI inference backends.
+type AIBackend interface {
+	// Complete sends a prompt and returns the text completion.
+	Complete(ctx context.Context, prompt string) (string, error)
+}
+
+// CLIBackend calls an external command (ollama, ramalama, etc.) for inference.
+type CLIBackend struct {
+	command string
+	timeout time.Duration
+}
+
+// NewCLIBackend creates a CLIBackend from a command string (e.g., "ollama run llama3.2:3b").
+func NewCLIBackend(command string, timeout time.Duration) *CLIBackend {
+	return &CLIBackend{command: command, timeout: timeout}
+}
+
+// Complete runs the CLI command with the prompt piped to stdin.
+func (b *CLIBackend) Complete(ctx context.Context, prompt string) (string, error) {
+	if b.timeout > 0 {
+		var cancel context.CancelFunc
+
+		ctx, cancel = context.WithTimeout(ctx, b.timeout)
+		defer cancel()
+	}
+
+	parts := strings.Fields(b.command)
+	if len(parts) == 0 {
+		return "", fmt.Errorf("ai_analysis: empty CLI command")
+	}
+
+	cmd := exec.CommandContext(ctx, parts[0], parts[1:]...) //nolint:gosec // user-configured command
+	cmd.Stdin = strings.NewReader(prompt)
+
+	out, err := cmd.Output()
+	if err != nil {
+		if ctx.Err() != nil {
+			return "", fmt.Errorf("ai_analysis: CLI command timed out: %w", ctx.Err())
+		}
+
+		return "", fmt.Errorf("ai_analysis: CLI command failed: %w", err)
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}
+
+// HTTPBackend calls an OpenAI-compatible chat completions endpoint.
+type HTTPBackend struct {
+	url     string
+	headers map[string]string
+	model   string
+	timeout time.Duration
+	client  *http.Client
+}
+
+// NewHTTPBackend creates an HTTPBackend for OpenAI-compatible APIs.
+func NewHTTPBackend(url string, headers map[string]string, model string, timeout time.Duration) *HTTPBackend {
+	return &HTTPBackend{
+		url:     url,
+		headers: headers,
+		model:   model,
+		timeout: timeout,
+		client:  &http.Client{},
+	}
+}
+
+type openAIChatRequest struct {
+	Model    string              `json:"model"`
+	Messages []openAIChatMessage `json:"messages"`
+}
+
+type openAIChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openAIChatResponse struct {
+	Choices []struct {
+		Message openAIChatMessage `json:"message"`
+	} `json:"choices"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// Complete sends a chat completion request to the configured HTTP endpoint.
+func (b *HTTPBackend) Complete(ctx context.Context, prompt string) (string, error) {
+	if b.timeout > 0 {
+		var cancel context.CancelFunc
+
+		ctx, cancel = context.WithTimeout(ctx, b.timeout)
+		defer cancel()
+	}
+
+	reqBody := openAIChatRequest{
+		Model: b.model,
+		Messages: []openAIChatMessage{
+			{Role: "user", Content: prompt},
+		},
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("ai_analysis: failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, b.url, bytes.NewReader(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("ai_analysis: failed to create HTTP request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	for k, v := range b.headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := b.client.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return "", fmt.Errorf("ai_analysis: HTTP request timed out: %w", ctx.Err())
+		}
+
+		return "", fmt.Errorf("ai_analysis: HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("ai_analysis: failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("ai_analysis: HTTP error %d: %s", resp.StatusCode, string(body))
+	}
+
+	var chatResp openAIChatResponse
+	if err := json.Unmarshal(body, &chatResp); err != nil {
+		return "", fmt.Errorf("ai_analysis: failed to decode response: %w", err)
+	}
+
+	if chatResp.Error != nil {
+		return "", fmt.Errorf("ai_analysis: API error: %s", chatResp.Error.Message)
+	}
+
+	if len(chatResp.Choices) == 0 {
+		return "", fmt.Errorf("ai_analysis: no choices in response")
+	}
+
+	return strings.TrimSpace(chatResp.Choices[0].Message.Content), nil
+}
+
+// AIPrompts holds configurable prompt templates. Use {content} as the placeholder.
+type AIPrompts struct {
+	Summarize      string `json:"summarize"       yaml:"summarize"`
+	Prioritize     string `json:"prioritize"      yaml:"prioritize"`
+	ExtractActions string `json:"extract_actions" yaml:"extract_actions"`
+}
+
+func defaultPrompts() AIPrompts {
+	return AIPrompts{
+		Summarize:      "Summarize this content in 2-3 sentences: {content}",
+		Prioritize:     defaultPromptPrioritize,
+		ExtractActions: defaultPromptExtractActions,
+	}
+}
+
+// AIAnalysisTransformer enriches items with AI-generated summary, priority score,
+// and action items. Results are stored in item metadata so the FullItem interface
+// is not modified.
+type AIAnalysisTransformer struct {
+	backend       AIBackend
+	prompts       AIPrompts
+	retryAttempts int
+	retryDelay    time.Duration
+	batchSize     int
+	onFailure     string // "log_and_continue", "fail_fast", "skip_item"
+	enabled       bool
+	config        map[string]interface{}
+}
+
+// NewAIAnalysisTransformer creates an AIAnalysisTransformer with no backend configured.
+// Call Configure with a valid config map before use.
+func NewAIAnalysisTransformer() *AIAnalysisTransformer {
+	return &AIAnalysisTransformer{
+		prompts:       defaultPrompts(),
+		retryAttempts: defaultRetryAttempts,
+		retryDelay:    defaultRetryDelay,
+		batchSize:     defaultBatchSize,
+		onFailure:     errorStrategyLogAndContinue,
+		enabled:       false,
+		config:        make(map[string]interface{}),
+	}
+}
+
+func (t *AIAnalysisTransformer) Name() string {
+	return transformerNameAIAnalysis
+}
+
+// Configure parses the ai_analysis transformer config block.
+//
+// Supported keys:
+//
+//	backend: "cli" | "http"
+//	cli.command: string (e.g. "ollama run llama3.2:3b")
+//	cli.timeout: string duration (e.g. "30s")
+//	http.url: string
+//	http.headers: map[string]string
+//	http.model: string
+//	http.timeout: string duration
+//	prompts.summarize / prompts.prioritize / prompts.extract_actions: string with {content}
+//	retry_attempts: int
+//	retry_delay: string duration
+//	batch_size: int
+//	on_failure: "log_and_continue" | "fail_fast" | "skip_item"
+func (t *AIAnalysisTransformer) Configure(config map[string]interface{}) error {
+	t.config = config
+
+	backendType, _ := config["backend"].(string)
+	if backendType == "" {
+		// No backend configured — transformer is a no-op (graceful degradation).
+		t.enabled = false
+
+		return nil
+	}
+
+	switch backendType {
+	case "cli":
+		backend, err := t.buildCLIBackend(config)
+		if err != nil {
+			return err
+		}
+
+		t.backend = backend
+	case "http":
+		backend, err := t.buildHTTPBackend(config)
+		if err != nil {
+			return err
+		}
+
+		t.backend = backend
+	default:
+		return fmt.Errorf("ai_analysis: unknown backend %q (must be 'cli' or 'http')", backendType)
+	}
+
+	t.prompts = t.parsePrompts(config)
+	t.retryAttempts = t.intConfig(config, "retry_attempts", defaultRetryAttempts)
+	t.retryDelay = t.durationConfig(config, "retry_delay", defaultRetryDelay)
+	t.batchSize = t.intConfig(config, "batch_size", defaultBatchSize)
+
+	if onFailure, ok := config["on_failure"].(string); ok {
+		t.onFailure = onFailure
+	}
+
+	t.enabled = true
+
+	return nil
+}
+
+// Transform processes items through AI analysis in batches.
+// When the AI backend is unavailable, items pass through unmodified (graceful degradation).
+func (t *AIAnalysisTransformer) Transform(items []models.FullItem) ([]models.FullItem, error) {
+	if !t.enabled || t.backend == nil {
+		return items, nil
+	}
+
+	result := make([]models.FullItem, 0, len(items))
+
+	for start := 0; start < len(items); start += t.batchSize {
+		end := start + t.batchSize
+		if end > len(items) {
+			end = len(items)
+		}
+
+		batch := items[start:end]
+
+		processed, err := t.processBatch(batch)
+		if err != nil {
+			switch t.onFailure {
+			case errorStrategyFailFast:
+				return nil, err
+			case errorStrategySkipItem:
+				log.Printf("Warning: ai_analysis batch failed, skipping %d items: %v", len(batch), err)
+
+				continue
+			default: // log_and_continue
+				log.Printf("Warning: ai_analysis batch failed, passing items through unchanged: %v", err)
+
+				result = append(result, batch...)
+
+				continue
+			}
+		}
+
+		result = append(result, processed...)
+	}
+
+	return result, nil
+}
+
+// processBatch runs AI analysis on a slice of items.
+// For skip_item and fail_fast failure modes, an error is returned so the caller
+// can skip or abort the entire batch. For log_and_continue, failed items are
+// kept as-is and no error is returned.
+func (t *AIAnalysisTransformer) processBatch(items []models.FullItem) ([]models.FullItem, error) {
+	result := make([]models.FullItem, 0, len(items))
+
+	for _, item := range items {
+		enriched, err := t.analyzeItem(item)
+		if err != nil {
+			switch t.onFailure {
+			case errorStrategyFailFast:
+				return nil, fmt.Errorf("ai_analysis: item %q failed: %w", item.GetID(), err)
+			case errorStrategySkipItem:
+				// Return error so the batch-level handler skips the whole batch.
+				return nil, fmt.Errorf("ai_analysis: item %q failed: %w", item.GetID(), err)
+			default: // log_and_continue
+				log.Printf("Warning: ai_analysis item %q failed, keeping original: %v", item.GetID(), err)
+				result = append(result, item)
+
+				continue
+			}
+		}
+
+		result = append(result, enriched)
+	}
+
+	return result, nil
+}
+
+// analyzeItem runs all configured AI prompts against a single item.
+func (t *AIAnalysisTransformer) analyzeItem(item models.FullItem) (models.FullItem, error) {
+	content := item.GetContent()
+	if strings.TrimSpace(content) == "" {
+		// Nothing to analyze — return as-is.
+		return item, nil
+	}
+
+	ctx := context.Background()
+
+	// Collect metadata updates.
+	extra := make(map[string]interface{})
+
+	if t.prompts.Summarize != "" {
+		summary, err := t.completeWithRetry(ctx, t.buildPrompt(t.prompts.Summarize, content))
+		if err != nil {
+			return nil, fmt.Errorf("summarize: %w", err)
+		}
+
+		extra[metaKeyAISummary] = summary
+	}
+
+	if t.prompts.Prioritize != "" {
+		priorityStr, err := t.completeWithRetry(ctx, t.buildPrompt(t.prompts.Prioritize, content))
+		if err != nil {
+			return nil, fmt.Errorf("prioritize: %w", err)
+		}
+
+		extra[metaKeyAIPriority] = parsePriorityScore(priorityStr)
+	}
+
+	if t.prompts.ExtractActions != "" {
+		actionsStr, err := t.completeWithRetry(ctx, t.buildPrompt(t.prompts.ExtractActions, content))
+		if err != nil {
+			return nil, fmt.Errorf("extract_actions: %w", err)
+		}
+
+		extra[metaKeyAIActionItems] = parseActionItems(actionsStr)
+	}
+
+	return withMetadata(item, extra), nil
+}
+
+// completeWithRetry calls the backend with exponential backoff.
+func (t *AIAnalysisTransformer) completeWithRetry(ctx context.Context, prompt string) (string, error) {
+	var lastErr error
+
+	for attempt := 0; attempt < t.retryAttempts; attempt++ {
+		if attempt > 0 {
+			delay := t.retryDelay * time.Duration(1<<uint(attempt-1))
+			time.Sleep(delay)
+		}
+
+		result, err := t.backend.Complete(ctx, prompt)
+		if err == nil {
+			return result, nil
+		}
+
+		lastErr = err
+	}
+
+	return "", fmt.Errorf("failed after %d attempts: %w", t.retryAttempts, lastErr)
+}
+
+// buildPrompt substitutes {content} in the template.
+func (t *AIAnalysisTransformer) buildPrompt(template, content string) string {
+	return strings.ReplaceAll(template, "{content}", content)
+}
+
+// withMetadata returns a copy of item with extra metadata merged in.
+func withMetadata(item models.FullItem, extra map[string]interface{}) models.FullItem {
+	existing := item.GetMetadata()
+	merged := make(map[string]interface{}, len(existing)+len(extra))
+
+	for k, v := range existing {
+		merged[k] = v
+	}
+
+	for k, v := range extra {
+		merged[k] = v
+	}
+
+	// Clone the item and set the new metadata.
+	cloned := cloneFullItem(item)
+	cloned.SetMetadata(merged)
+
+	return cloned
+}
+
+// cloneFullItem creates a shallow copy of the item preserving its concrete type.
+func cloneFullItem(item models.FullItem) models.FullItem {
+	if thread, ok := models.AsThread(item); ok {
+		newThread := models.NewThread(thread.GetID(), thread.GetTitle())
+		newThread.SetContent(thread.GetContent())
+		newThread.SetSourceType(thread.GetSourceType())
+		newThread.SetItemType(thread.GetItemType())
+		newThread.SetCreatedAt(thread.GetCreatedAt())
+		newThread.SetUpdatedAt(thread.GetUpdatedAt())
+		newThread.SetTags(thread.GetTags())
+		newThread.SetAttachments(thread.GetAttachments())
+		newThread.SetMetadata(thread.GetMetadata())
+		newThread.SetLinks(thread.GetLinks())
+		newThread.SetMessages(thread.GetMessages())
+
+		return newThread
+	}
+
+	newItem := models.NewBasicItem(item.GetID(), item.GetTitle())
+	newItem.SetContent(item.GetContent())
+	newItem.SetSourceType(item.GetSourceType())
+	newItem.SetItemType(item.GetItemType())
+	newItem.SetCreatedAt(item.GetCreatedAt())
+	newItem.SetUpdatedAt(item.GetUpdatedAt())
+	newItem.SetTags(item.GetTags())
+	newItem.SetAttachments(item.GetAttachments())
+	newItem.SetMetadata(item.GetMetadata())
+	newItem.SetLinks(item.GetLinks())
+
+	return newItem
+}
+
+// parsePriorityScore parses the model's response into a float64 in [0,1].
+func parsePriorityScore(s string) float64 {
+	s = strings.TrimSpace(s)
+
+	var score float64
+
+	if _, err := fmt.Sscanf(s, "%f", &score); err != nil {
+		return 0
+	}
+
+	if score < 0 {
+		return 0
+	}
+
+	if score > 1 {
+		return 1
+	}
+
+	return score
+}
+
+// parseActionItems parses a JSON array of strings from the model's response.
+func parseActionItems(s string) []string {
+	s = strings.TrimSpace(s)
+
+	// Find the first '[' to be tolerant of leading prose.
+	start := strings.Index(s, "[")
+	end := strings.LastIndex(s, "]")
+
+	if start == -1 || end == -1 || end <= start {
+		if s != "" {
+			return []string{s}
+		}
+
+		return []string{}
+	}
+
+	jsonArray := s[start : end+1]
+
+	var items []string
+	if err := json.Unmarshal([]byte(jsonArray), &items); err != nil {
+		return []string{s}
+	}
+
+	return items
+}
+
+// --- Config helpers ---
+
+func (t *AIAnalysisTransformer) buildCLIBackend(config map[string]interface{}) (*CLIBackend, error) {
+	cliCfg, _ := config["cli"].(map[string]interface{})
+	if cliCfg == nil {
+		return nil, fmt.Errorf("ai_analysis: 'cli' config block required for CLI backend")
+	}
+
+	command, _ := cliCfg["command"].(string)
+	if command == "" {
+		return nil, fmt.Errorf("ai_analysis: cli.command is required")
+	}
+
+	timeout := t.durationConfig(cliCfg, "timeout", defaultTimeout)
+
+	return NewCLIBackend(command, timeout), nil
+}
+
+func (t *AIAnalysisTransformer) buildHTTPBackend(config map[string]interface{}) (*HTTPBackend, error) {
+	httpCfg, _ := config["http"].(map[string]interface{})
+	if httpCfg == nil {
+		return nil, fmt.Errorf("ai_analysis: 'http' config block required for HTTP backend")
+	}
+
+	url, _ := httpCfg["url"].(string)
+	if url == "" {
+		return nil, fmt.Errorf("ai_analysis: http.url is required")
+	}
+
+	model, _ := httpCfg["model"].(string)
+	timeout := t.durationConfig(httpCfg, "timeout", defaultTimeout)
+
+	headers := make(map[string]string)
+
+	if rawHeaders, ok := httpCfg["headers"].(map[string]interface{}); ok {
+		for k, v := range rawHeaders {
+			if sv, ok := v.(string); ok {
+				headers[k] = sv
+			}
+		}
+	}
+
+	return NewHTTPBackend(url, headers, model, timeout), nil
+}
+
+func (t *AIAnalysisTransformer) parsePrompts(config map[string]interface{}) AIPrompts {
+	p := defaultPrompts()
+
+	promptCfg, ok := config["prompts"].(map[string]interface{})
+	if !ok {
+		return p
+	}
+
+	if v, ok := promptCfg["summarize"].(string); ok && v != "" {
+		p.Summarize = v
+	}
+
+	if v, ok := promptCfg["prioritize"].(string); ok && v != "" {
+		p.Prioritize = v
+	}
+
+	if v, ok := promptCfg["extract_actions"].(string); ok && v != "" {
+		p.ExtractActions = v
+	}
+
+	return p
+}
+
+func (t *AIAnalysisTransformer) intConfig(config map[string]interface{}, key string, defaultVal int) int {
+	v, ok := config[key]
+	if !ok {
+		return defaultVal
+	}
+
+	switch n := v.(type) {
+	case int:
+		return n
+	case float64:
+		return int(n)
+	}
+
+	return defaultVal
+}
+
+func (t *AIAnalysisTransformer) durationConfig(
+	config map[string]interface{},
+	key string,
+	defaultVal time.Duration,
+) time.Duration {
+	s, ok := config[key].(string)
+	if !ok || s == "" {
+		return defaultVal
+	}
+
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return defaultVal
+	}
+
+	return d
+}
+
+// GetAISummary returns the AI-generated summary stored in item metadata.
+func GetAISummary(item models.FullItem) string {
+	v, _ := item.GetMetadata()[metaKeyAISummary].(string)
+
+	return v
+}
+
+// GetAIPriorityScore returns the AI-generated priority score stored in item metadata.
+func GetAIPriorityScore(item models.FullItem) float64 {
+	v, _ := item.GetMetadata()[metaKeyAIPriority].(float64)
+
+	return v
+}
+
+// GetAIActionItems returns the AI-generated action items stored in item metadata.
+func GetAIActionItems(item models.FullItem) []string {
+	v, _ := item.GetMetadata()[metaKeyAIActionItems].([]string)
+
+	return v
+}
+
+// Ensure interface compliance.
+var _ interfaces.Transformer = (*AIAnalysisTransformer)(nil)

--- a/internal/transform/ai_analysis.go
+++ b/internal/transform/ai_analysis.go
@@ -23,7 +23,6 @@ const (
 	metaKeyAISummary     = "ai_summary"
 	metaKeyAIPriority    = "ai_priority_score"
 	metaKeyAIActionItems = "ai_action_items"
-	metaKeyAITags        = "ai_tags"
 
 	defaultRetryAttempts = 3
 	defaultRetryDelay    = time.Second
@@ -218,7 +217,6 @@ type AIAnalysisTransformer struct {
 	batchSize     int
 	onFailure     string // "log_and_continue", "fail_fast", "skip_item"
 	enabled       bool
-	config        map[string]interface{}
 }
 
 // NewAIAnalysisTransformer creates an AIAnalysisTransformer with no backend configured.
@@ -231,7 +229,6 @@ func NewAIAnalysisTransformer() *AIAnalysisTransformer {
 		batchSize:     defaultBatchSize,
 		onFailure:     errorStrategyLogAndContinue,
 		enabled:       false,
-		config:        make(map[string]interface{}),
 	}
 }
 
@@ -255,9 +252,10 @@ func (t *AIAnalysisTransformer) Name() string {
 //	retry_delay: string duration
 //	batch_size: int
 //	on_failure: "log_and_continue" | "fail_fast" | "skip_item"
+//	  - log_and_continue: keep original item unmodified on failure (default)
+//	  - fail_fast: abort the entire Transform call on first failure
+//	  - skip_item: skip the entire batch containing the failed item (not just the individual item)
 func (t *AIAnalysisTransformer) Configure(config map[string]interface{}) error {
-	t.config = config
-
 	backendType, _ := config["backend"].(string)
 	if backendType == "" {
 		// No backend configured — transformer is a no-op (graceful degradation).

--- a/internal/transform/ai_analysis_test.go
+++ b/internal/transform/ai_analysis_test.go
@@ -1,0 +1,520 @@
+package transform
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"pkm-sync/pkg/models"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockBackend is a test AI backend that returns canned responses.
+type mockBackend struct {
+	response string
+	err      error
+	calls    int
+}
+
+func (m *mockBackend) Complete(_ context.Context, _ string) (string, error) {
+	m.calls++
+
+	return m.response, m.err
+}
+
+// errorAfterN fails for the first N calls then succeeds.
+type errorAfterN struct {
+	failCount int
+	calls     int
+	response  string
+}
+
+func (e *errorAfterN) Complete(_ context.Context, _ string) (string, error) {
+	e.calls++
+	if e.calls <= e.failCount {
+		return "", fmt.Errorf("transient error %d", e.calls)
+	}
+
+	return e.response, nil
+}
+
+func makeItem(id, content string) models.FullItem {
+	item := models.NewBasicItem(id, "Test Item "+id)
+	item.SetContent(content)
+	item.SetMetadata(map[string]interface{}{})
+
+	return item
+}
+
+// --- AIAnalysisTransformer ---
+
+func TestAIAnalysisTransformer_Name(t *testing.T) {
+	tr := NewAIAnalysisTransformer()
+	assert.Equal(t, transformerNameAIAnalysis, tr.Name())
+}
+
+func TestAIAnalysisTransformer_DisabledByDefault(t *testing.T) {
+	tr := NewAIAnalysisTransformer()
+	items := []models.FullItem{makeItem("1", "some content")}
+
+	out, err := tr.Transform(items)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	// No metadata should be added when disabled.
+	assert.Empty(t, GetAISummary(out[0]))
+}
+
+func TestAIAnalysisTransformer_Configure_NilBackend(t *testing.T) {
+	tr := NewAIAnalysisTransformer()
+	err := tr.Configure(map[string]interface{}{
+		// no backend key
+	})
+	require.NoError(t, err)
+	assert.False(t, tr.enabled)
+}
+
+func TestAIAnalysisTransformer_Configure_UnknownBackend(t *testing.T) {
+	tr := NewAIAnalysisTransformer()
+	err := tr.Configure(map[string]interface{}{
+		"backend": "grpc",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown backend")
+}
+
+func TestAIAnalysisTransformer_Configure_CLIMissingCommand(t *testing.T) {
+	tr := NewAIAnalysisTransformer()
+	err := tr.Configure(map[string]interface{}{
+		"backend": "cli",
+		"cli":     map[string]interface{}{},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cli.command")
+}
+
+func TestAIAnalysisTransformer_Configure_HTTPMissingURL(t *testing.T) {
+	tr := NewAIAnalysisTransformer()
+	err := tr.Configure(map[string]interface{}{
+		"backend": "http",
+		"http":    map[string]interface{}{},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "http.url")
+}
+
+func TestAIAnalysisTransformer_TransformEnrichesItems(t *testing.T) {
+	tr := NewAIAnalysisTransformer()
+	tr.enabled = true
+	tr.batchSize = 10
+	tr.retryAttempts = 1
+	tr.onFailure = "log_and_continue"
+
+	// Use a custom backend that rotates responses.
+	responses := []string{
+		"This is a summary.",        // summarize
+		"0.8",                       // prioritize
+		`["buy milk","call Alice"]`, // extract_actions
+	}
+	tr.backend = &rotatingBackend{responses: responses}
+
+	items := []models.FullItem{makeItem("item1", "Full content here.")}
+	out, err := tr.Transform(items)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+
+	assert.Equal(t, "This is a summary.", GetAISummary(out[0]))
+	assert.InDelta(t, 0.8, GetAIPriorityScore(out[0]), 0.001)
+	assert.Equal(t, []string{"buy milk", "call Alice"}, GetAIActionItems(out[0]))
+}
+
+func TestAIAnalysisTransformer_EmptyContentSkipped(t *testing.T) {
+	tr := NewAIAnalysisTransformer()
+	tr.enabled = true
+	tr.batchSize = 10
+	tr.retryAttempts = 1
+	tr.backend = &mockBackend{response: "summary"}
+	tr.prompts = defaultPrompts()
+
+	item := makeItem("empty", "")
+	out, err := tr.Transform([]models.FullItem{item})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	// No AI metadata should be added for empty content.
+	assert.Empty(t, GetAISummary(out[0]))
+}
+
+func TestAIAnalysisTransformer_GracefulDegradationOnError(t *testing.T) {
+	tr := NewAIAnalysisTransformer()
+	tr.enabled = true
+	tr.batchSize = 10
+	tr.retryAttempts = 1
+	tr.retryDelay = 0
+	tr.onFailure = "log_and_continue"
+	tr.backend = &mockBackend{err: fmt.Errorf("backend unavailable")}
+	tr.prompts = defaultPrompts()
+
+	item := makeItem("1", "content")
+	out, err := tr.Transform([]models.FullItem{item})
+	require.NoError(t, err)
+	// Item passes through unchanged.
+	require.Len(t, out, 1)
+	assert.Equal(t, "content", out[0].GetContent())
+}
+
+func TestAIAnalysisTransformer_FailFast(t *testing.T) {
+	tr := NewAIAnalysisTransformer()
+	tr.enabled = true
+	tr.batchSize = 10
+	tr.retryAttempts = 1
+	tr.retryDelay = 0
+	tr.onFailure = "fail_fast"
+	tr.backend = &mockBackend{err: fmt.Errorf("backend down")}
+	tr.prompts = defaultPrompts()
+
+	_, err := tr.Transform([]models.FullItem{makeItem("1", "content")})
+	require.Error(t, err)
+}
+
+func TestAIAnalysisTransformer_SkipItem(t *testing.T) {
+	tr := NewAIAnalysisTransformer()
+	tr.enabled = true
+	tr.batchSize = 10
+	tr.retryAttempts = 1
+	tr.retryDelay = 0
+	tr.onFailure = "skip_item"
+	tr.backend = &mockBackend{err: fmt.Errorf("backend down")}
+	tr.prompts = defaultPrompts()
+
+	// skip_item: batch is skipped entirely so result is empty.
+	out, err := tr.Transform([]models.FullItem{makeItem("1", "content")})
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+func TestAIAnalysisTransformer_RetryOnTransientError(t *testing.T) {
+	tr := NewAIAnalysisTransformer()
+	tr.enabled = true
+	tr.batchSize = 10
+	tr.retryAttempts = 3
+	tr.retryDelay = time.Millisecond
+	tr.onFailure = "fail_fast"
+	tr.prompts = AIPrompts{Summarize: "Summarize: {content}"}
+
+	backend := &errorAfterN{failCount: 2, response: "ok summary"}
+	tr.backend = backend
+
+	out, err := tr.Transform([]models.FullItem{makeItem("1", "content")})
+	require.NoError(t, err)
+	assert.Equal(t, "ok summary", GetAISummary(out[0]))
+	assert.Equal(t, 3, backend.calls) // 2 failures + 1 success
+}
+
+func TestAIAnalysisTransformer_BatchProcessing(t *testing.T) {
+	tr := NewAIAnalysisTransformer()
+	tr.enabled = true
+	tr.batchSize = 2
+	tr.retryAttempts = 1
+	tr.retryDelay = 0
+	tr.onFailure = "log_and_continue"
+	tr.prompts = AIPrompts{Summarize: "Summarize: {content}"}
+	tr.backend = &mockBackend{response: "batch summary"}
+
+	items := []models.FullItem{
+		makeItem("1", "content1"),
+		makeItem("2", "content2"),
+		makeItem("3", "content3"),
+	}
+
+	out, err := tr.Transform(items)
+	require.NoError(t, err)
+	assert.Len(t, out, 3)
+
+	for _, item := range out {
+		assert.Equal(t, "batch summary", GetAISummary(item))
+	}
+}
+
+func TestAIAnalysisTransformer_PreservesExistingMetadata(t *testing.T) {
+	tr := NewAIAnalysisTransformer()
+	tr.enabled = true
+	tr.batchSize = 10
+	tr.retryAttempts = 1
+	tr.retryDelay = 0
+	tr.onFailure = "fail_fast"
+	tr.prompts = AIPrompts{Summarize: "Summarize: {content}"}
+	tr.backend = &mockBackend{response: "summary"}
+
+	item := makeItem("1", "content")
+	item.SetMetadata(map[string]interface{}{"existing_key": "existing_value"})
+
+	out, err := tr.Transform([]models.FullItem{item})
+	require.NoError(t, err)
+
+	meta := out[0].GetMetadata()
+	assert.Equal(t, "existing_value", meta["existing_key"])
+	assert.Equal(t, "summary", meta[metaKeyAISummary])
+}
+
+func TestAIAnalysisTransformer_ThreadItemPreserved(t *testing.T) {
+	tr := NewAIAnalysisTransformer()
+	tr.enabled = true
+	tr.batchSize = 10
+	tr.retryAttempts = 1
+	tr.retryDelay = 0
+	tr.onFailure = "fail_fast"
+	tr.prompts = AIPrompts{Summarize: "Summarize: {content}"}
+	tr.backend = &mockBackend{response: "thread summary"}
+
+	thread := models.NewThread("t1", "Thread Subject")
+	thread.SetContent("thread content")
+	thread.SetMetadata(map[string]interface{}{})
+
+	out, err := tr.Transform([]models.FullItem{thread})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+
+	_, isThread := models.AsThread(out[0])
+	assert.True(t, isThread, "output should still be a Thread")
+	assert.Equal(t, "thread summary", GetAISummary(out[0]))
+}
+
+// --- parsePriorityScore ---
+
+func TestParsePriorityScore(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected float64
+	}{
+		{"0.8", 0.8},
+		{"1", 1.0},
+		{"0", 0.0},
+		{"  0.5  ", 0.5},
+		{"not a number", 0},
+		{"1.5", 1.0}, // clamped
+		{"-0.1", 0},  // clamped
+		{"0.0", 0.0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := parsePriorityScore(tc.input)
+			assert.InDelta(t, tc.expected, got, 0.001)
+		})
+	}
+}
+
+// --- parseActionItems ---
+
+func TestParseActionItems(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "valid JSON array",
+			input:    `["buy milk", "call Alice"]`,
+			expected: []string{"buy milk", "call Alice"},
+		},
+		{
+			name:     "JSON array with leading text",
+			input:    "Here are the actions:\n[\"action 1\",\"action 2\"]",
+			expected: []string{"action 1", "action 2"},
+		},
+		{
+			name:     "empty array",
+			input:    "[]",
+			expected: []string{},
+		},
+		{
+			name:     "plain text fallback",
+			input:    "just a single action",
+			expected: []string{"just a single action"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseActionItems(tc.input)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+// --- HTTPBackend ---
+
+func TestHTTPBackend_Complete(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+
+		resp := openAIChatResponse{
+			Choices: []struct {
+				Message openAIChatMessage `json:"message"`
+			}{
+				{Message: openAIChatMessage{Role: "assistant", Content: "test response"}},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	backend := NewHTTPBackend(
+		server.URL,
+		map[string]string{"Authorization": "Bearer test-key"},
+		"gpt-4o",
+		5*time.Second,
+	)
+
+	result, err := backend.Complete(context.Background(), "test prompt")
+	require.NoError(t, err)
+	assert.Equal(t, "test response", result)
+}
+
+func TestHTTPBackend_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	backend := NewHTTPBackend(server.URL, nil, "model", 5*time.Second)
+	_, err := backend.Complete(context.Background(), "prompt")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestHTTPBackend_Timeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(2 * time.Second):
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	backend := NewHTTPBackend(server.URL, nil, "model", 50*time.Millisecond)
+	_, err := backend.Complete(context.Background(), "prompt")
+	require.Error(t, err)
+}
+
+// --- CLIBackend ---
+
+func TestCLIBackend_Complete_Echo(t *testing.T) {
+	backend := NewCLIBackend("echo hello", 5*time.Second)
+	result, err := backend.Complete(context.Background(), "anything")
+	require.NoError(t, err)
+	assert.Equal(t, "hello", result)
+}
+
+func TestCLIBackend_InvalidCommand(t *testing.T) {
+	backend := NewCLIBackend("nonexistent-command-xyz", 5*time.Second)
+	_, err := backend.Complete(context.Background(), "prompt")
+	require.Error(t, err)
+}
+
+func TestCLIBackend_EmptyCommand(t *testing.T) {
+	backend := NewCLIBackend("", 5*time.Second)
+	_, err := backend.Complete(context.Background(), "prompt")
+	require.Error(t, err)
+}
+
+// --- Configure integration ---
+
+func TestConfigure_CLIBackend(t *testing.T) {
+	tr := NewAIAnalysisTransformer()
+	err := tr.Configure(map[string]interface{}{
+		"backend": "cli",
+		"cli": map[string]interface{}{
+			"command": "echo hi",
+			"timeout": "10s",
+		},
+		"retry_attempts": float64(2),
+		"retry_delay":    "500ms",
+		"batch_size":     float64(5),
+		"on_failure":     "skip_item",
+	})
+	require.NoError(t, err)
+	assert.True(t, tr.enabled)
+	assert.Equal(t, 2, tr.retryAttempts)
+	assert.Equal(t, 5, tr.batchSize)
+	assert.Equal(t, "skip_item", tr.onFailure)
+	assert.Equal(t, 500*time.Millisecond, tr.retryDelay)
+}
+
+func TestConfigure_HTTPBackend(t *testing.T) {
+	tr := NewAIAnalysisTransformer()
+	err := tr.Configure(map[string]interface{}{
+		"backend": "http",
+		"http": map[string]interface{}{
+			"url":   "https://api.example.com/v1/chat/completions",
+			"model": "gpt-4o",
+			"headers": map[string]interface{}{
+				"Authorization": "Bearer sk-test",
+			},
+			"timeout": "30s",
+		},
+		"prompts": map[string]interface{}{
+			"summarize":       "Custom summarize: {content}",
+			"prioritize":      "Custom prioritize: {content}",
+			"extract_actions": "Custom actions: {content}",
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, tr.enabled)
+	assert.Equal(t, "Custom summarize: {content}", tr.prompts.Summarize)
+	assert.Equal(t, "Custom prioritize: {content}", tr.prompts.Prioritize)
+	assert.Equal(t, "Custom actions: {content}", tr.prompts.ExtractActions)
+}
+
+// --- Helper accessors ---
+
+func TestGetAIHelpers_Empty(t *testing.T) {
+	item := makeItem("1", "content")
+
+	assert.Equal(t, "", GetAISummary(item))
+	assert.Equal(t, 0.0, GetAIPriorityScore(item))
+	assert.Nil(t, GetAIActionItems(item))
+}
+
+// --- rotatingBackend helper ---
+
+type rotatingBackend struct {
+	responses []string
+	idx       int
+}
+
+func (r *rotatingBackend) Complete(_ context.Context, _ string) (string, error) {
+	if r.idx >= len(r.responses) {
+		return "", fmt.Errorf("no more responses")
+	}
+
+	resp := r.responses[r.idx]
+	r.idx++
+
+	return resp, nil
+}
+
+// --- buildPrompt ---
+
+func TestBuildPrompt(t *testing.T) {
+	tr := NewAIAnalysisTransformer()
+	result := tr.buildPrompt("Summarize: {content}", "hello world")
+	assert.Equal(t, "Summarize: hello world", result)
+	assert.False(t, strings.Contains(result, "{content}"))
+}

--- a/internal/transform/examples.go
+++ b/internal/transform/examples.go
@@ -366,5 +366,6 @@ func GetAllContentProcessingTransformers() []interfaces.Transformer {
 		NewThreadGroupingTransformer(),   // Thread consolidation from thread_grouping.go
 		NewAutoTaggingTransformer(),      // Existing example transformer
 		NewFilterTransformer(),           // Existing example transformer
+		NewAIAnalysisTransformer(),       // AI-powered content analysis (disabled until configured)
 	}
 }

--- a/internal/transform/examples_test.go
+++ b/internal/transform/examples_test.go
@@ -261,17 +261,17 @@ func TestFilterTransformerInvalidConfig(t *testing.T) {
 }
 
 func TestGetAllExampleTransformers(t *testing.T) {
-	// GetAllExampleTransformers now returns all 6 transformers (same as GetAllContentProcessingTransformers).
+	// GetAllExampleTransformers now returns all 7 transformers (same as GetAllContentProcessingTransformers).
 	transformers := GetAllExampleTransformers()
-	if len(transformers) != 6 {
-		t.Errorf("Expected 6 transformers, got %d", len(transformers))
+	if len(transformers) != 7 {
+		t.Errorf("Expected 7 transformers, got %d", len(transformers))
 	}
 }
 
 func TestGetAllContentProcessingTransformers(t *testing.T) {
 	transformers := GetAllContentProcessingTransformers()
-	if len(transformers) != 6 {
-		t.Errorf("Expected 6 content processing transformers, got %d", len(transformers))
+	if len(transformers) != 7 {
+		t.Errorf("Expected 7 content processing transformers, got %d", len(transformers))
 	}
 }
 

--- a/internal/transform/pipeline.go
+++ b/internal/transform/pipeline.go
@@ -8,6 +8,13 @@ import (
 	"pkm-sync/pkg/models"
 )
 
+// Error strategy constants used across the transform package.
+const (
+	errorStrategyFailFast       = "fail_fast"
+	errorStrategyLogAndContinue = "log_and_continue"
+	errorStrategySkipItem       = "skip_item"
+)
+
 // DefaultTransformPipeline implements the TransformPipeline interface using FullItem.
 type DefaultTransformPipeline struct {
 	transformers        []interfaces.Transformer
@@ -95,7 +102,7 @@ func (p *DefaultTransformPipeline) Transform(items []models.FullItem) ([]models.
 				return nil, err
 			}
 			// currentItems remains unchanged for log_and_continue, or becomes empty for skip_item
-			if p.config.ErrorStrategy == "skip_item" {
+			if p.config.ErrorStrategy == errorStrategySkipItem {
 				currentItems = []models.FullItem{}
 			}
 		} else {
@@ -130,11 +137,11 @@ func (p *DefaultTransformPipeline) handleTransformerError(
 	err error,
 ) error {
 	switch p.config.ErrorStrategy {
-	case "fail_fast":
+	case errorStrategyFailFast:
 		return fmt.Errorf("transformer '%s' failed: %w", transformer.Name(), err)
-	case "log_and_continue":
+	case errorStrategyLogAndContinue:
 		p.logTransformerError(transformer, items, err, "Continuing with previous items")
-	case "skip_item":
+	case errorStrategySkipItem:
 		p.logTransformerError(transformer, items, err, "skipping this batch")
 	default:
 		return fmt.Errorf("unknown error strategy '%s'", p.config.ErrorStrategy)


### PR DESCRIPTION
## Summary

Implements the AI Content Analysis Transformer requested in #20.

- **`AIAnalysisTransformer`** in `internal/transform/ai_analysis.go` — enriches items with AI-generated summaries, priority scores, and action items stored in item metadata (`ai_summary`, `ai_priority_score`, `ai_action_items`)
- **`CLIBackend`** — executes external tools (ollama, ramalama, custom commands) via stdin/stdout
- **`HTTPBackend`** — calls OpenAI-compatible chat completions endpoints with configurable headers/auth
- Configurable prompt templates with `{content}` substitution
- Retry logic with exponential backoff (`retry_attempts`, `retry_delay`)
- Three failure strategies: `log_and_continue` (default), `fail_fast`, `skip_item` (batch-level)
- Graceful degradation: transformer is a no-op when no backend is configured
- Batch processing with configurable `batch_size`
- Registered in `GetAllContentProcessingTransformers()` pipeline factory
- Helper accessor functions: `GetAISummary`, `GetAIPriorityScore`, `GetAIActionItems`
- Error strategy strings extracted to package-level constants (`pipeline.go`) to resolve goconst lint violations

## Configuration example

```yaml
transformers:
  pipeline_order: ["content_cleanup", "ai_analysis", "auto_tagging"]
  ai_analysis:
    enabled: true
    backend: "cli"
    cli:
      command: "ollama run llama3.2:3b"
      timeout: "30s"
    # OR HTTP backend:
    # backend: "http"
    # http:
    #   url: "https://api.openai.com/v1/chat/completions"
    #   headers:
    #     Authorization: "Bearer ${OPENAI_API_KEY}"
    #   model: "gpt-4o"
    #   timeout: "30s"
    prompts:
      summarize: "Summarize this content in 2-3 sentences: {content}"
      prioritize: "Rate importance 0-1: {content}"
      extract_actions: "List action items as JSON array: {content}"
    batch_size: 10
    retry_attempts: 3
    retry_delay: "1s"
    on_failure: "log_and_continue"
```

## Test plan

- [x] Unit tests for all transformer behaviours (enabled/disabled, graceful degradation, retry, batch, fail_fast, skip_item)
- [x] Unit tests for `parsePriorityScore` and `parseActionItems` edge cases
- [x] HTTP backend tested against `httptest.NewServer` (happy path, 500 error, timeout)
- [x] CLI backend tested with `echo` command
- [x] Thread item type preserved through transformation
- [x] Existing metadata preserved when AI metadata is added
- [x] Lint clean (`golangci-lint v2.4.0`), race detector clean

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)