### PR TITLE
feat(cli): verb-centric command structure (fetch, search, sync)

### DIFF
--- a/cmd/drive_fetch.go
+++ b/cmd/drive_fetch.go
@@ -25,8 +25,9 @@ var (
 )
 
 var driveFetchCmd = &cobra.Command{
-	Use:   "fetch <URL>",
-	Short: "Fetch a Google Drive document by URL",
+	Use:        "fetch <URL>",
+	Short:      "Fetch a Google Drive document by URL",
+	Deprecated: "use 'pkm-sync fetch <URL>' instead",
 	Long: `Fetch a Google Drive document by URL and output its content.
 
 By default, content is written to stdout. Use --output to write a markdown

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -19,20 +19,20 @@ var (
 )
 
 var driveCmd = &cobra.Command{
-	Use:   "drive",
-	Short: "Sync Google Drive documents to PKM systems",
+	Use:        "drive",
+	Short:      "Sync Google Drive documents to PKM systems",
+	Deprecated: "use 'pkm-sync sync drive' or 'pkm-sync sync --source <name>' instead. For single docs: 'pkm-sync fetch <URL>'",
 	Long: `Sync Google Drive documents (Google Docs, Sheets, Slides) to PKM targets.
 
 Configure google_drive sources in your config file to specify folders,
 shared drives, and export formats.
 
-Use the fetch subcommand to fetch a single document by URL:
-  pkm-sync drive fetch <URL>
+Use 'pkm-sync fetch <URL>' to fetch a single document by URL:
+  pkm-sync fetch "https://docs.google.com/document/d/abc123/edit"
 
 Examples:
   pkm-sync drive --source my_drive --target obsidian --output ./vault
-  pkm-sync drive --since 7d --dry-run
-  pkm-sync drive fetch "https://docs.google.com/document/d/abc123/edit"`,
+  pkm-sync drive --since 7d --dry-run`,
 	RunE: runDriveCommand,
 }
 

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -13,6 +13,7 @@ import (
 	"pkm-sync/internal/sources/google/auth"
 	"pkm-sync/internal/sources/google/drive"
 	jirasource "pkm-sync/internal/sources/jira"
+	"pkm-sync/internal/utils"
 	"pkm-sync/pkg/interfaces"
 	"pkm-sync/pkg/models"
 	"pkm-sync/pkg/routing"
@@ -99,9 +100,9 @@ func runFetchCommand(cmd *cobra.Command, args []string) error {
 }
 
 // runFetchByURL uses the resolve.Engine to fetch an item by URL.
-// Tries all configured resolvers; Drive and Jira are supported out of the box.
+// When fetchCmdSource is set, only resolvers matching that source name are used.
 func runFetchByURL(ctx context.Context, id routing.ParsedIdentifier) error {
-	resolvers, err := buildResolvers()
+	resolvers, err := buildResolvers(fetchCmdSource)
 	if err != nil {
 		return err
 	}
@@ -119,6 +120,14 @@ func runFetchByURL(ctx context.Context, id routing.ParsedIdentifier) error {
 
 	if item == nil {
 		return fmt.Errorf("no resolver matched URL %q", id.URL)
+	}
+
+	// Append Drive comments when requested.
+	if fetchCmdComments {
+		item, err = appendDriveComments(item, id.URL)
+		if err != nil {
+			return err
+		}
 	}
 
 	return outputFetchedItem(item, id.URL)
@@ -209,53 +218,91 @@ func runFetchBySourceName(ctx context.Context, key, sourceName string) error {
 }
 
 // buildResolvers constructs a resolver slice from available auth and config.
+// sourceName optionally restricts to a specific configured source (by name).
 // Drive resolution only requires Google OAuth. Jira resolution additionally
 // requires a configured jira source (for the instance URL).
-func buildResolvers() ([]interfaces.Resolver, error) {
+func buildResolvers(sourceName string) ([]interfaces.Resolver, error) {
 	var resolvers []interfaces.Resolver
 
-	// Drive resolver — requires only Google OAuth.
-	client, authErr := auth.GetClient()
-	if authErr == nil {
-		svc, svcErr := drive.NewService(client)
-		if svcErr == nil {
-			// Use default Drive config (empty DriveSourceConfig is fine for fetch).
-			resolvers = append(resolvers, resolve.NewDriveResolver(svc, models.DriveSourceConfig{}))
+	// Drive resolver — requires only Google OAuth. Skip when --source names a
+	// non-drive source explicitly.
+	addDrive := sourceName == "" || isSourceNameOfType(sourceName, "google_drive")
+	if addDrive {
+		client, authErr := auth.GetClient()
+		if authErr == nil {
+			svc, svcErr := drive.NewService(client)
+			if svcErr == nil {
+				resolvers = append(resolvers, resolve.NewDriveResolver(svc, models.DriveSourceConfig{}))
+			}
+		} else if sourceName != "" {
+			// Explicit drive source requested but auth failed — surface the error.
+			return nil, fmt.Errorf("authentication required: %w", authErr)
 		}
 	}
 
-	// Jira resolver — requires a configured jira source.
-	cfg, cfgErr := config.LoadConfig()
-	if cfgErr == nil {
-		for srcName, sc := range cfg.Sources {
-			if !sc.Enabled || sc.Type != "jira" {
-				continue
-			}
-
-			jiraSrc := jirasource.NewJiraSource(srcName, sc)
-			if err := jiraSrc.Configure(nil, nil); err != nil {
-				continue // skip if auth fails; don't abort
-			}
-
-			instanceURL := sc.Jira.InstanceURL
-			if instanceURL == "" {
-				continue // can't build a resolver without an instance URL
-			}
-
-			jr, err := resolve.NewJiraResolver(jiraSrc, instanceURL)
-			if err != nil {
-				continue
-			}
-
-			resolvers = append(resolvers, jr)
-		}
+	// Jira resolvers — one per configured jira source. When sourceName is set,
+	// only build the resolver for that specific source.
+	if cfg, err := config.LoadConfig(); err == nil {
+		resolvers = buildJiraResolvers(resolvers, cfg.Sources, sourceName)
 	}
 
-	if len(resolvers) == 0 && authErr != nil {
-		return nil, fmt.Errorf("authentication required: %w", authErr)
+	if len(resolvers) == 0 {
+		return nil, fmt.Errorf("no resolvers available (check authentication and source configuration)")
 	}
 
 	return resolvers, nil
+}
+
+// isSourceNameOfType returns true when the named source has the given canonical
+// type, or when sourceName is empty (no restriction).
+func isSourceNameOfType(sourceName, canonicalType string) bool {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return false
+	}
+
+	sc, ok := cfg.Sources[sourceName]
+
+	return ok && sc.Type == canonicalType
+}
+
+// appendDriveComments fetches Drive document comments and appends them as
+// markdown footnotes when --comments is set. Only applies to Drive items;
+// other source types are returned unchanged.
+func appendDriveComments(item models.FullItem, sourceURL string) (models.FullItem, error) {
+	if item.GetSourceType() != "google_drive" {
+		return item, nil
+	}
+
+	fileID, err := drive.ExtractFileID(sourceURL)
+	if err != nil {
+		return item, nil // not a Drive URL we can extract from — skip silently
+	}
+
+	client, err := auth.GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("authentication required for --comments: %w", err)
+	}
+
+	svc, err := drive.NewService(client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create drive service: %w", err)
+	}
+
+	comments, err := svc.GetComments(fileID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch comments: %w", err)
+	}
+
+	if len(comments) == 0 {
+		return item, nil
+	}
+
+	content := drive.InsertCommentMarkers(item.GetContent(), comments)
+	content += "\n\n" + drive.FormatCommentsAsFootnotes(comments)
+	item.SetContent(content)
+
+	return item, nil
 }
 
 // outputFetchedItem writes item content to stdout or to a file per CLI flags.
@@ -278,6 +325,10 @@ func outputFetchedItem(item models.FullItem, sourceURL string) error {
 
 		if fetchCmdOutput != "" {
 			outPath := resolveItemOutputPath(fetchCmdOutput, item.GetTitle(), "json")
+
+			if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
+				return fmt.Errorf("failed to create directory: %w", err)
+			}
 
 			return os.WriteFile(outPath, data, 0644)
 		}
@@ -342,6 +393,38 @@ func writeFetchedItemToFile(item models.FullItem, sourceURL, content, outputFlag
 	return nil
 }
 
+// buildJiraResolvers appends a JiraResolver for each enabled jira source in
+// sources. When sourceName is non-empty only that source is considered.
+func buildJiraResolvers(resolvers []interfaces.Resolver, sources map[string]models.SourceConfig, sourceName string) []interfaces.Resolver {
+	for name, sc := range sources {
+		if !sc.Enabled || sc.Type != "jira" {
+			continue
+		}
+
+		if sourceName != "" && name != sourceName {
+			continue
+		}
+
+		if sc.Jira.InstanceURL == "" {
+			continue
+		}
+
+		jiraSrc := jirasource.NewJiraSource(name, sc)
+		if err := jiraSrc.Configure(nil, nil); err != nil {
+			continue
+		}
+
+		jr, err := resolve.NewJiraResolver(jiraSrc, sc.Jira.InstanceURL)
+		if err != nil {
+			continue
+		}
+
+		resolvers = append(resolvers, jr)
+	}
+
+	return resolvers
+}
+
 // resolveItemOutputPath determines the output path for a fetched item.
 // If outputFlag is an existing directory or ends with /, the title is used as filename.
 func resolveItemOutputPath(outputFlag, title, format string) string {
@@ -349,20 +432,10 @@ func resolveItemOutputPath(outputFlag, title, format string) string {
 
 	info, err := os.Stat(outputFlag)
 	if (err == nil && info.IsDir()) || strings.HasSuffix(outputFlag, "/") {
-		safe := sanitizeFetchFilename(title)
+		safe := utils.SanitizeFilename(title)
 
 		return filepath.Join(outputFlag, safe+ext)
 	}
 
 	return outputFlag
-}
-
-// sanitizeFetchFilename makes an item title safe for use as a filename.
-func sanitizeFetchFilename(title string) string {
-	replacer := strings.NewReplacer(
-		"/", "-", "\\", "-", ":", "-", "*", "", "?", "",
-		"\"", "", "<", "", ">", "", "|", "",
-	)
-
-	return replacer.Replace(title)
 }

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -1,0 +1,368 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"pkm-sync/internal/config"
+	"pkm-sync/internal/resolve"
+	"pkm-sync/internal/sinks"
+	"pkm-sync/internal/sources/google/auth"
+	"pkm-sync/internal/sources/google/drive"
+	jirasource "pkm-sync/internal/sources/jira"
+	"pkm-sync/pkg/interfaces"
+	"pkm-sync/pkg/models"
+	"pkm-sync/pkg/routing"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	fetchCmdSource   string
+	fetchCmdFormat   string
+	fetchCmdOutput   string
+	fetchCmdComments bool
+)
+
+var fetchCmd = &cobra.Command{
+	Use:   "fetch <url-or-identifier>",
+	Short: "Fetch a single item by URL or source-qualified identifier",
+	Long: `Fetch a single item by URL or identifier and output its content.
+
+Identifier formats:
+
+  URL (auto-routed):
+    pkm-sync fetch https://docs.google.com/document/d/ID/edit
+    pkm-sync fetch https://company.atlassian.net/browse/PROJ-123
+
+  Source-type prefix:
+    pkm-sync fetch jira/PROJ-123
+    pkm-sync fetch drive/FILE_ID
+    pkm-sync fetch drive/https://docs.google.com/document/d/ID/edit
+
+  When multiple sources of the same type exist, use --source to disambiguate:
+    pkm-sync fetch jira/PROJ-123 --source jira_work
+
+By default content is written to stdout. Use --output to write a markdown file
+with YAML frontmatter (enables re-fetch later).
+
+Output formats:
+  txt  : Plain text (default for stdout)
+  md   : Markdown (default for --output)
+  json : Raw JSON item representation
+
+Examples:
+  pkm-sync fetch "https://docs.google.com/document/d/abc123/edit"
+  pkm-sync fetch "https://docs.google.com/document/d/abc123/edit" --format md --comments
+  pkm-sync fetch "https://docs.google.com/document/d/abc123/edit" --output ./docs/
+  pkm-sync fetch jira/PROJ-123
+  pkm-sync fetch jira/PROJ-123 --source jira_work --output ./jira/`,
+	Args: cobra.ExactArgs(1),
+	RunE: runFetchCommand,
+}
+
+func init() {
+	rootCmd.AddCommand(fetchCmd)
+	fetchCmd.Flags().StringVar(&fetchCmdSource, "source", "", "Source name when multiple sources of the same type are configured")
+	fetchCmd.Flags().StringVar(&fetchCmdFormat, "format", "", "Output format (txt, md, json). Defaults to md with --output, txt otherwise")
+	fetchCmd.Flags().StringVarP(&fetchCmdOutput, "output", "o", "", "Write to file/directory with frontmatter")
+	fetchCmd.Flags().BoolVar(&fetchCmdComments, "comments", false, "Append document comments as markdown footnotes (Drive documents)")
+}
+
+func runFetchCommand(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	id := routing.Parse(args[0])
+
+	// Case 1 & 2: the identifier is (or contains) a URL — route through resolvers.
+	if id.IsURL {
+		return runFetchByURL(ctx, id)
+	}
+
+	// Case 3: source-type/key — use the Fetcher interface on a configured source.
+	if id.SourceType != "" {
+		return runFetchByKey(ctx, id)
+	}
+
+	// Case 4: bare key — need --source to identify the source.
+	if fetchCmdSource == "" {
+		return fmt.Errorf("identifier %q is ambiguous: use source-type prefix (e.g. jira/%s) or --source flag", args[0], args[0])
+	}
+
+	return runFetchBySourceName(ctx, id.Key, fetchCmdSource)
+}
+
+// runFetchByURL uses the resolve.Engine to fetch an item by URL.
+// Tries all configured resolvers; Drive and Jira are supported out of the box.
+func runFetchByURL(ctx context.Context, id routing.ParsedIdentifier) error {
+	resolvers, err := buildResolvers()
+	if err != nil {
+		return err
+	}
+
+	if len(resolvers) == 0 {
+		return fmt.Errorf("no resolvers available for URL %q (check authentication)", id.URL)
+	}
+
+	engine := resolve.NewEngine(resolvers)
+
+	item, err := engine.ResolveURL(ctx, id.URL)
+	if err != nil {
+		return fmt.Errorf("fetch failed: %w", err)
+	}
+
+	if item == nil {
+		return fmt.Errorf("no resolver matched URL %q", id.URL)
+	}
+
+	return outputFetchedItem(item, id.URL)
+}
+
+// runFetchByKey looks up a configured source by type prefix and calls FetchOne.
+func runFetchByKey(ctx context.Context, id routing.ParsedIdentifier) error {
+	canonicalType := routing.CanonicalSourceType(id.SourceType)
+
+	// For Drive with a file ID, construct a URL and route through the resolver.
+	// This avoids duplicating the export logic that already lives in DriveResolver.
+	if canonicalType == "google_drive" && !strings.HasPrefix(id.Key, "http") {
+		driveURL := "https://drive.google.com/file/d/" + id.Key + "/view"
+
+		return runFetchByURL(ctx, routing.ParsedIdentifier{
+			Raw:        id.Raw,
+			IsURL:      true,
+			URL:        driveURL,
+			SourceType: id.SourceType,
+			Key:        id.Key,
+		})
+	}
+
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	srcName, sc, err := findSourceByType(cfg, canonicalType, fetchCmdSource)
+	if err != nil {
+		return fmt.Errorf("cannot fetch %s/%s: %w", id.SourceType, id.Key, err)
+	}
+
+	src, err := createSourceWithConfig(srcName, sc, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create source %q: %w", srcName, err)
+	}
+
+	fetcher, ok := src.(interfaces.Fetcher)
+	if !ok {
+		return fmt.Errorf("source type %q does not support single-item fetch", id.SourceType)
+	}
+
+	item, err := fetcher.FetchOne(ctx, id.Key)
+	if err != nil {
+		return fmt.Errorf("fetch failed: %w", err)
+	}
+
+	if item == nil {
+		return fmt.Errorf("item %q not found in source %q", id.Key, srcName)
+	}
+
+	return outputFetchedItem(item, "")
+}
+
+// runFetchBySourceName looks up a source by explicit name and calls FetchOne.
+func runFetchBySourceName(ctx context.Context, key, sourceName string) error {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	sc, ok := cfg.Sources[sourceName]
+	if !ok {
+		return fmt.Errorf("source %q not found in config", sourceName)
+	}
+
+	src, err := createSourceWithConfig(sourceName, sc, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create source %q: %w", sourceName, err)
+	}
+
+	fetcher, fok := src.(interfaces.Fetcher)
+	if !fok {
+		return fmt.Errorf("source %q (type %q) does not support single-item fetch", sourceName, sc.Type)
+	}
+
+	item, err := fetcher.FetchOne(ctx, key)
+	if err != nil {
+		return fmt.Errorf("fetch failed: %w", err)
+	}
+
+	if item == nil {
+		return fmt.Errorf("item %q not found in source %q", key, sourceName)
+	}
+
+	return outputFetchedItem(item, "")
+}
+
+// buildResolvers constructs a resolver slice from available auth and config.
+// Drive resolution only requires Google OAuth. Jira resolution additionally
+// requires a configured jira source (for the instance URL).
+func buildResolvers() ([]interfaces.Resolver, error) {
+	var resolvers []interfaces.Resolver
+
+	// Drive resolver — requires only Google OAuth.
+	client, authErr := auth.GetClient()
+	if authErr == nil {
+		svc, svcErr := drive.NewService(client)
+		if svcErr == nil {
+			// Use default Drive config (empty DriveSourceConfig is fine for fetch).
+			resolvers = append(resolvers, resolve.NewDriveResolver(svc, models.DriveSourceConfig{}))
+		}
+	}
+
+	// Jira resolver — requires a configured jira source.
+	cfg, cfgErr := config.LoadConfig()
+	if cfgErr == nil {
+		for srcName, sc := range cfg.Sources {
+			if !sc.Enabled || sc.Type != "jira" {
+				continue
+			}
+
+			jiraSrc := jirasource.NewJiraSource(srcName, sc)
+			if err := jiraSrc.Configure(nil, nil); err != nil {
+				continue // skip if auth fails; don't abort
+			}
+
+			instanceURL := sc.Jira.InstanceURL
+			if instanceURL == "" {
+				continue // can't build a resolver without an instance URL
+			}
+
+			jr, err := resolve.NewJiraResolver(jiraSrc, instanceURL)
+			if err != nil {
+				continue
+			}
+
+			resolvers = append(resolvers, jr)
+		}
+	}
+
+	if len(resolvers) == 0 && authErr != nil {
+		return nil, fmt.Errorf("authentication required: %w", authErr)
+	}
+
+	return resolvers, nil
+}
+
+// outputFetchedItem writes item content to stdout or to a file per CLI flags.
+// sourceURL is the original URL (used for frontmatter when writing Drive docs).
+func outputFetchedItem(item models.FullItem, sourceURL string) error {
+	format := fetchCmdFormat
+	if format == "" {
+		if fetchCmdOutput != "" {
+			format = "md"
+		} else {
+			format = "txt"
+		}
+	}
+
+	if format == "json" {
+		data, err := item.MarshalJSON()
+		if err != nil {
+			return fmt.Errorf("failed to serialize item: %w", err)
+		}
+
+		if fetchCmdOutput != "" {
+			outPath := resolveItemOutputPath(fetchCmdOutput, item.GetTitle(), "json")
+
+			return os.WriteFile(outPath, data, 0644)
+		}
+
+		_, err = os.Stdout.Write(data)
+
+		return err
+	}
+
+	content := item.GetContent()
+
+	if fetchCmdOutput != "" {
+		return writeFetchedItemToFile(item, sourceURL, content, fetchCmdOutput)
+	}
+
+	_, err := fmt.Fprint(os.Stdout, content)
+
+	return err
+}
+
+// writeFetchedItemToFile writes a fetched item to a markdown file with YAML
+// frontmatter. For Drive documents the source URL is embedded so that
+// 'pkm-sync drive refresh' can re-fetch later.
+func writeFetchedItemToFile(item models.FullItem, sourceURL, content, outputFlag string) error {
+	outPath := resolveItemOutputPath(outputFlag, item.GetTitle(), "md")
+
+	if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	// Build a BasicItem so we get consistent frontmatter via the Obsidian formatter.
+	meta := item.GetMetadata()
+	if meta == nil {
+		meta = make(map[string]any)
+	}
+
+	if sourceURL != "" {
+		meta["source_url"] = sourceURL
+	}
+
+	bi := &models.BasicItem{
+		ID:         item.GetID(),
+		Title:      item.GetTitle(),
+		SourceType: item.GetSourceType(),
+		ItemType:   item.GetItemType(),
+		Content:    content,
+		CreatedAt:  item.GetCreatedAt(),
+		UpdatedAt:  item.GetUpdatedAt(),
+		Tags:       item.GetTags(),
+		Metadata:   meta,
+	}
+
+	formatter := sinks.NewObsidianFormatterPublic()
+	formatted := formatter.FormatItemContent(bi)
+
+	if err := os.WriteFile(outPath, []byte(formatted), 0644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", outPath, err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Wrote %s\n", outPath)
+
+	return nil
+}
+
+// resolveItemOutputPath determines the output path for a fetched item.
+// If outputFlag is an existing directory or ends with /, the title is used as filename.
+func resolveItemOutputPath(outputFlag, title, format string) string {
+	ext := "." + format
+
+	info, err := os.Stat(outputFlag)
+	if (err == nil && info.IsDir()) || strings.HasSuffix(outputFlag, "/") {
+		safe := sanitizeFetchFilename(title)
+
+		return filepath.Join(outputFlag, safe+ext)
+	}
+
+	return outputFlag
+}
+
+// sanitizeFetchFilename makes an item title safe for use as a filename.
+func sanitizeFetchFilename(title string) string {
+	replacer := strings.NewReplacer(
+		"/", "-", "\\", "-", ":", "-", "*", "", "?", "",
+		"\"", "", "<", "", ">", "", "|", "",
+	)
+
+	return replacer.Replace(title)
+}

--- a/cmd/gmail.go
+++ b/cmd/gmail.go
@@ -19,8 +19,9 @@ var (
 )
 
 var gmailCmd = &cobra.Command{
-	Use:   "gmail",
-	Short: "Sync Gmail emails to PKM systems",
+	Use:        "gmail",
+	Short:      "Sync Gmail emails to PKM systems",
+	Deprecated: "use 'pkm-sync sync gmail' or 'pkm-sync sync --source <name>' instead",
 	Long: `Sync Gmail emails to PKM targets (obsidian, logseq, etc.)
 
 Examples:

--- a/cmd/jira.go
+++ b/cmd/jira.go
@@ -17,8 +17,9 @@ var (
 )
 
 var jiraCmd = &cobra.Command{
-	Use:   "jira",
-	Short: "Sync Jira issues to PKM systems",
+	Use:        "jira",
+	Short:      "Sync Jira issues to PKM systems",
+	Deprecated: "use 'pkm-sync sync jira' or 'pkm-sync sync --source <name>' instead. For single issues: 'pkm-sync fetch jira/PROJ-123'",
 	Long: `Sync Jira issues from configured sources to PKM targets.
 
 Examples:

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -5,11 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
+	"pkm-sync/internal/archive"
 	"pkm-sync/internal/config"
 	"pkm-sync/internal/vectorstore"
+	"pkm-sync/pkg/routing"
 
 	"github.com/spf13/cobra"
 )
@@ -23,16 +26,32 @@ var (
 )
 
 var searchCmd = &cobra.Command{
-	Use:   "search <query>",
-	Short: "Search indexed Gmail messages using semantic search",
-	Long: `Search indexed Gmail messages using semantic search.
-Returns threads ranked by similarity to your query.
+	Use:   "search [type[/source]] <query>",
+	Short: "Search indexed items using semantic search or Gmail full-text search",
+	Long: `Search indexed items using semantic (vector) search or Gmail full-text search.
+
+An optional first argument scopes the search to a source type or a specific
+source instance. The query is always the last argument.
+
+  Bare query — vector (semantic) search across all sources:
+    pkm-sync search "kubernetes deployment issues"
+
+  Source type — routes to the appropriate backend:
+    pkm-sync search gmail "meeting with alice"      # Gmail FTS (archive.db)
+    pkm-sync search slack "deploy failed"           # vector search, slack filter
+    pkm-sync search jira "authentication error"     # vector search, jira filter
+
+  Type/source — narrows to a specific configured source:
+    pkm-sync search gmail/work_gmail "rosa boundary"
+    pkm-sync search jira/jira_work "auth error"
 
 Examples:
   pkm-sync search "kubernetes deployment issues"
-  pkm-sync search "meetings with alice" --limit 5
-  pkm-sync search "project status" --source-name gmail_work --format json`,
-	Args: cobra.ExactArgs(1),
+  pkm-sync search gmail "rosa boundary"
+  pkm-sync search gmail/work_gmail "rosa boundary"
+  pkm-sync search slack "deploy failed" --limit 5
+  pkm-sync search "project status" --format json`,
+	Args: cobra.RangeArgs(1, 2),
 	RunE: runSearchCommand,
 }
 
@@ -47,9 +66,85 @@ func init() {
 
 func runSearchCommand(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
-	query := args[0]
 
-	// Load configuration
+	// Two-arg form: search <type[/source]> <query>
+	// One-arg form: search <query>
+	var query string
+
+	sourceTypeFilter := searchSourceType
+	sourceName := searchSourceName
+
+	if len(args) == 2 {
+		query = args[1]
+		// Parse the source specifier: "gmail" or "gmail/work_gmail"
+		specifier := args[0]
+		if idx := strings.Index(specifier, "/"); idx >= 0 {
+			sourceName = specifier[idx+1:]
+			specifier = specifier[:idx]
+		}
+
+		if sourceTypeFilter == "" {
+			sourceTypeFilter = routing.CanonicalSourceType(specifier)
+		}
+	} else {
+		query = args[0]
+	}
+
+	// Route gmail queries to the FTS archive when available.
+	if sourceTypeFilter == "gmail" {
+		if handled, err := runGmailFTSSearch(query, sourceName); handled {
+			return err
+		}
+		// Fall through to vector search if archive.db is not available.
+	}
+
+	// Default path: vector (semantic) search.
+	return runVectorSearch(ctx, query, sourceTypeFilter, sourceName)
+}
+
+// runGmailFTSSearch performs full-text search against archive.db.
+// sourceName optionally filters to a specific source (e.g. "work_gmail").
+// Returns (true, err) when the archive was found and queried (even on query error).
+// Returns (false, nil) when archive.db doesn't exist, so the caller can fall through.
+func runGmailFTSSearch(query, sourceName string) (bool, error) {
+	configDir, err := config.GetConfigDir()
+	if err != nil {
+		return false, nil
+	}
+
+	dbPath := filepath.Join(configDir, "archive.db")
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		return false, nil // archive not set up, fall through to vector search
+	}
+
+	store, err := archive.NewStore(dbPath)
+	if err != nil {
+		return true, fmt.Errorf("failed to open archive: %w", err)
+	}
+	defer store.Close()
+
+	results, err := store.Search(query, searchLimit)
+	if err != nil {
+		return true, fmt.Errorf("archive search failed: %w", err)
+	}
+
+	// Filter by source name when specified.
+	if sourceName != "" {
+		filtered := results[:0]
+		for _, r := range results {
+			if r.SourceName == sourceName {
+				filtered = append(filtered, r)
+			}
+		}
+
+		results = filtered
+	}
+
+	return true, outputArchiveResults(query, results)
+}
+
+// runVectorSearch performs semantic (KNN) search against vectors.db.
+func runVectorSearch(ctx context.Context, query, sourceTypeFilter, sourceName string) error {
 	cfg, err := config.LoadConfig()
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
@@ -61,20 +156,17 @@ func runSearchCommand(cmd *cobra.Command, args []string) error {
 	}
 	defer vectorSink.Close()
 
-	// Build search filters
 	filters := vectorstore.SearchFilters{
-		SourceType: searchSourceType,
-		SourceName: searchSourceName,
+		SourceType: sourceTypeFilter,
+		SourceName: sourceName,
 		MinScore:   searchMinScore,
 	}
 
-	// Search
 	results, err := vectorSink.Search(ctx, query, searchLimit, filters)
 	if err != nil {
 		return fmt.Errorf("failed to search: %w", err)
 	}
 
-	// Output results
 	switch searchFormat {
 	case "json":
 		return outputJSON(query, results)
@@ -83,6 +175,26 @@ func runSearchCommand(cmd *cobra.Command, args []string) error {
 	default:
 		return fmt.Errorf("unsupported format: %s (supported: text, json)", searchFormat)
 	}
+}
+
+// outputArchiveResults prints Gmail FTS results.
+func outputArchiveResults(query string, results []archive.FTSResult) error {
+	if len(results) == 0 {
+		fmt.Printf("No Gmail archive results for %q\n", query)
+
+		return nil
+	}
+
+	fmt.Printf("Found %d Gmail archive result(s) for %q:\n\n", len(results), query)
+
+	for i, r := range results {
+		fmt.Printf("%d. %s\n", i+1, r.Subject)
+		fmt.Printf("   From: %s | Source: %s | Date: %s\n",
+			r.FromAddr, r.SourceName, r.DateSent.Format("2006-01-02"))
+		fmt.Println()
+	}
+
+	return nil
 }
 
 // outputText outputs search results in human-readable text format.

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -74,20 +74,10 @@ func runSearchCommand(cmd *cobra.Command, args []string) error {
 	sourceTypeFilter := searchSourceType
 	sourceName := searchSourceName
 
-	if len(args) == 2 {
-		query = args[1]
-		// Parse the source specifier: "gmail" or "gmail/work_gmail"
-		specifier := args[0]
-		if idx := strings.Index(specifier, "/"); idx >= 0 {
-			sourceName = specifier[idx+1:]
-			specifier = specifier[:idx]
-		}
-
-		if sourceTypeFilter == "" {
-			sourceTypeFilter = routing.CanonicalSourceType(specifier)
-		}
-	} else {
+	if len(args) == 1 {
 		query = args[0]
+	} else {
+		query, sourceTypeFilter, sourceName = parseSearchSpecifier(args[1], args[0], sourceTypeFilter, sourceName)
 	}
 
 	// Route gmail queries to the FTS archive when available.
@@ -100,6 +90,26 @@ func runSearchCommand(cmd *cobra.Command, args []string) error {
 
 	// Default path: vector (semantic) search.
 	return runVectorSearch(ctx, query, sourceTypeFilter, sourceName)
+}
+
+// parseSearchSpecifier parses the optional first positional argument of the
+// two-arg search form: `search <specifier> <query>`. The specifier is either a
+// bare source type ("gmail") or "type/sourceName". Returns updated query,
+// sourceTypeFilter, and sourceName values.
+func parseSearchSpecifier(query, specifier, sourceTypeFilter, sourceName string) (string, string, string) {
+	if idx := strings.Index(specifier, "/"); idx >= 0 {
+		if sourceName == "" { // flag takes precedence over positional inference
+			sourceName = specifier[idx+1:]
+		}
+
+		specifier = specifier[:idx]
+	}
+
+	if sourceTypeFilter == "" {
+		sourceTypeFilter = routing.CanonicalSourceType(specifier)
+	}
+
+	return query, sourceTypeFilter, sourceName
 }
 
 // runGmailFTSSearch performs full-text search against archive.db.
@@ -123,12 +133,22 @@ func runGmailFTSSearch(query, sourceName string) (bool, error) {
 	}
 	defer store.Close()
 
-	results, err := store.Search(query, searchLimit)
+	// When filtering by source, fetch a larger set so the per-source results
+	// aren't truncated before we apply the filter. Otherwise use searchLimit.
+	fetchLimit := searchLimit
+	if sourceName != "" {
+		fetchLimit = 0 // store.Search treats 0 as its internal default (20); use a large cap
+		if searchLimit > 0 {
+			fetchLimit = searchLimit * 10 // generous multiplier to survive cross-source dilution
+		}
+	}
+
+	results, err := store.Search(query, fetchLimit)
 	if err != nil {
 		return true, fmt.Errorf("archive search failed: %w", err)
 	}
 
-	// Filter by source name when specified.
+	// Filter by source name when specified, then re-apply the user's limit.
 	if sourceName != "" {
 		filtered := results[:0]
 		for _, r := range results {
@@ -138,9 +158,12 @@ func runGmailFTSSearch(query, sourceName string) (bool, error) {
 		}
 
 		results = filtered
+		if searchLimit > 0 && len(results) > searchLimit {
+			results = results[:searchLimit]
+		}
 	}
 
-	return true, outputArchiveResults(query, results)
+	return true, outputArchiveResults(query, results, searchFormat)
 }
 
 // runVectorSearch performs semantic (KNN) search against vectors.db.
@@ -177,8 +200,43 @@ func runVectorSearch(ctx context.Context, query, sourceTypeFilter, sourceName st
 	}
 }
 
-// outputArchiveResults prints Gmail FTS results.
-func outputArchiveResults(query string, results []archive.FTSResult) error {
+// outputArchiveResults prints Gmail FTS results in text or JSON format.
+func outputArchiveResults(query string, results []archive.FTSResult, format string) error {
+	if format == "json" {
+		type jsonResult struct {
+			GmailID    string `json:"gmail_id"`
+			Subject    string `json:"subject"`
+			FromAddr   string `json:"from_addr"`
+			SourceName string `json:"source_name"`
+			DateSent   string `json:"date_sent"`
+		}
+
+		out := struct {
+			Query   string       `json:"query"`
+			Count   int          `json:"count"`
+			Results []jsonResult `json:"results"`
+		}{
+			Query:   query,
+			Count:   len(results),
+			Results: make([]jsonResult, len(results)),
+		}
+
+		for i, r := range results {
+			out.Results[i] = jsonResult{
+				GmailID:    r.GmailID,
+				Subject:    r.Subject,
+				FromAddr:   r.FromAddr,
+				SourceName: r.SourceName,
+				DateSent:   r.DateSent.Format(time.RFC3339),
+			}
+		}
+
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+
+		return enc.Encode(out)
+	}
+
 	if len(results) == 0 {
 		fmt.Printf("No Gmail archive results for %q\n", query)
 

--- a/cmd/servicenow.go
+++ b/cmd/servicenow.go
@@ -17,8 +17,9 @@ var (
 )
 
 var servicenowCmd = &cobra.Command{
-	Use:   "servicenow",
-	Short: "Sync ServiceNow tickets to PKM systems",
+	Use:        "servicenow",
+	Short:      "Sync ServiceNow tickets to PKM systems",
+	Deprecated: "use 'pkm-sync sync servicenow' or 'pkm-sync sync --source <name>' instead",
 	Long: `Sync ServiceNow tickets (RITMs, incidents, etc.) from configured sources to PKM targets.
 
 Examples:

--- a/cmd/slack.go
+++ b/cmd/slack.go
@@ -19,8 +19,9 @@ var (
 )
 
 var slackCmd = &cobra.Command{
-	Use:   "slack",
-	Short: "Sync Slack messages to SQLite archive",
+	Use:        "slack",
+	Short:      "Sync Slack messages to SQLite archive",
+	Deprecated: "use 'pkm-sync sync slack' or 'pkm-sync sync --source <name>' instead",
 	Long: `Sync Slack messages from configured sources into a SQLite archive with FTS5 full-text search.
 
 Examples:

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -67,34 +67,36 @@ func runSyncCommand(cmd *cobra.Command, args []string) error {
 		cfg = config.GetDefaultConfig()
 	}
 
-	// The optional positional arg can be a source name ("gmail_work") or a
-	// source type alias ("gmail", "drive"). It overrides --source when present.
-	if len(args) == 1 && syncSourceName == "" {
-		syncSourceName = resolveSyncPositionalArg(cfg, args[0])
+	// The optional positional arg can be a source name ("gmail_work") or a source
+	// type alias ("gmail", "drive"). Resolve into a local to avoid mutating the
+	// flag-backed global (which persists across in-process invocations).
+	resolvedSource := syncSourceName
+	if len(args) == 1 && resolvedSource == "" {
+		resolvedSource = resolveSyncPositionalArg(cfg, args[0])
 	}
 
 	// Determine which sources to sync.
-	// syncSourceName may be a source name ("gmail_work") or a canonical type
+	// resolvedSource may be a source name ("gmail_work") or a canonical type
 	// ("gmail", "google_drive") when set via the positional arg.
 	var sourcesToSync []string
 
 	switch {
-	case syncSourceName == "":
+	case resolvedSource == "":
 		sourcesToSync = getEnabledSources(cfg)
-	case isSourceType(syncSourceName):
+	case isSourceType(resolvedSource):
 		// Filter all enabled sources that match this canonical type.
 		for _, name := range getEnabledSources(cfg) {
-			if sc, ok := cfg.Sources[name]; ok && sc.Type == syncSourceName {
+			if sc, ok := cfg.Sources[name]; ok && sc.Type == resolvedSource {
 				sourcesToSync = append(sourcesToSync, name)
 			}
 		}
 
 		if len(sourcesToSync) == 0 {
-			return fmt.Errorf("no enabled sources of type %q found", syncSourceName)
+			return fmt.Errorf("no enabled sources of type %q found", resolvedSource)
 		}
 	default:
 		// Treat as a specific source name.
-		sourcesToSync = []string{syncSourceName}
+		sourcesToSync = []string{resolvedSource}
 	}
 
 	if len(sourcesToSync) == 0 {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -8,6 +8,8 @@ import (
 
 	"pkm-sync/internal/config"
 	"pkm-sync/internal/state"
+	"pkm-sync/pkg/models"
+	"pkm-sync/pkg/routing"
 
 	"github.com/spf13/cobra"
 )
@@ -23,16 +25,28 @@ var (
 )
 
 var syncCmd = &cobra.Command{
-	Use:   "sync",
+	Use:   "sync [source]",
 	Short: "Sync all enabled sources to PKM systems",
 	Long: `Sync all enabled sources (Gmail, Google Calendar, Drive, Slack, Jira) to PKM targets in a single operation.
 
+An optional positional argument can filter to a specific source type or source
+name. Source type aliases like "gmail", "drive", "jira", "slack" are accepted:
+
+  pkm-sync sync gmail           # all enabled Gmail sources
+  pkm-sync sync gmail_work      # specific source by name
+  pkm-sync sync drive           # all enabled Drive sources
+
+The --source flag is also accepted for backward compatibility.
+
 Examples:
   pkm-sync sync
+  pkm-sync sync gmail
+  pkm-sync sync gmail_work
   pkm-sync sync --source gmail_work
   pkm-sync sync --target obsidian --output ./vault
   pkm-sync sync --since 7d --dry-run
-  pkm-sync sync --source gmail_work --dry-run --format json`,
+  pkm-sync sync gmail --dry-run --format json`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: runSyncCommand,
 }
 
@@ -53,12 +67,34 @@ func runSyncCommand(cmd *cobra.Command, args []string) error {
 		cfg = config.GetDefaultConfig()
 	}
 
-	// Determine which sources to sync
+	// The optional positional arg can be a source name ("gmail_work") or a
+	// source type alias ("gmail", "drive"). It overrides --source when present.
+	if len(args) == 1 && syncSourceName == "" {
+		syncSourceName = resolveSyncPositionalArg(cfg, args[0])
+	}
+
+	// Determine which sources to sync.
+	// syncSourceName may be a source name ("gmail_work") or a canonical type
+	// ("gmail", "google_drive") when set via the positional arg.
 	var sourcesToSync []string
-	if syncSourceName != "" {
-		sourcesToSync = []string{syncSourceName}
-	} else {
+
+	switch {
+	case syncSourceName == "":
 		sourcesToSync = getEnabledSources(cfg)
+	case isSourceType(syncSourceName):
+		// Filter all enabled sources that match this canonical type.
+		for _, name := range getEnabledSources(cfg) {
+			if sc, ok := cfg.Sources[name]; ok && sc.Type == syncSourceName {
+				sourcesToSync = append(sourcesToSync, name)
+			}
+		}
+
+		if len(sourcesToSync) == 0 {
+			return fmt.Errorf("no enabled sources of type %q found", syncSourceName)
+		}
+	default:
+		// Treat as a specific source name.
+		sourcesToSync = []string{syncSourceName}
 	}
 
 	if len(sourcesToSync) == 0 {
@@ -222,4 +258,35 @@ func runSyncCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// knownSourceTypes is the set of canonical config type strings.
+var knownSourceTypes = map[string]bool{
+	"gmail": true, "google_calendar": true, "google_drive": true,
+	"slack": true, "jira": true, "servicenow": true,
+}
+
+// isSourceType returns true if s is a canonical source type string (not a name).
+func isSourceType(s string) bool {
+	return knownSourceTypes[s]
+}
+
+// resolveSyncPositionalArg maps a positional arg to a source name or type.
+// If arg matches a configured source name, it is returned as-is.
+// If arg matches a type alias (e.g. "gmail", "drive"), the canonical type is returned.
+// If neither matches, the arg is returned unchanged (will fail later with a clear error).
+func resolveSyncPositionalArg(cfg *models.Config, arg string) string {
+	// Exact source name match takes priority.
+	if _, ok := cfg.Sources[arg]; ok {
+		return arg
+	}
+
+	// Type alias → canonical type.
+	canonical := routing.CanonicalSourceType(arg)
+	if isSourceType(canonical) {
+		return canonical
+	}
+
+	// Return unchanged; the caller will produce a helpful error.
+	return arg
 }

--- a/cmd/verb_helpers.go
+++ b/cmd/verb_helpers.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"pkm-sync/pkg/models"
+)
+
+// findSourceByType searches the config for an enabled source matching
+// canonicalType (e.g. "google_drive", "jira"). If sourceName is non-empty it
+// must match exactly. Returns the source name and config on success.
+//
+// For sources that work without a config entry (Google Drive via OAuth), the
+// caller should fall back to a direct auth flow when this returns an error.
+func findSourceByType(cfg *models.Config, canonicalType, sourceName string) (string, models.SourceConfig, error) {
+	if sourceName != "" {
+		sc, ok := cfg.Sources[sourceName]
+		if !ok {
+			return "", models.SourceConfig{}, fmt.Errorf("source %q not found in config", sourceName)
+		}
+
+		if sc.Type != canonicalType {
+			return "", models.SourceConfig{}, fmt.Errorf("source %q has type %q, expected %q", sourceName, sc.Type, canonicalType)
+		}
+
+		return sourceName, sc, nil
+	}
+
+	var matches []string
+
+	for name, sc := range cfg.Sources {
+		if sc.Type == canonicalType && sc.Enabled {
+			matches = append(matches, name)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", models.SourceConfig{}, fmt.Errorf("no enabled %q source found in config", canonicalType)
+	case 1:
+		return matches[0], cfg.Sources[matches[0]], nil
+	default:
+		return "", models.SourceConfig{}, fmt.Errorf(
+			"multiple %q sources configured, use --source to specify one: %s",
+			canonicalType, strings.Join(matches, ", "),
+		)
+	}
+}

--- a/cmd/verb_helpers.go
+++ b/cmd/verb_helpers.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"pkm-sync/pkg/models"
@@ -18,6 +19,10 @@ func findSourceByType(cfg *models.Config, canonicalType, sourceName string) (str
 		sc, ok := cfg.Sources[sourceName]
 		if !ok {
 			return "", models.SourceConfig{}, fmt.Errorf("source %q not found in config", sourceName)
+		}
+
+		if !sc.Enabled {
+			return "", models.SourceConfig{}, fmt.Errorf("source %q is disabled", sourceName)
 		}
 
 		if sc.Type != canonicalType {
@@ -41,6 +46,8 @@ func findSourceByType(cfg *models.Config, canonicalType, sourceName string) (str
 	case 1:
 		return matches[0], cfg.Sources[matches[0]], nil
 	default:
+		sort.Strings(matches)
+
 		return "", models.SourceConfig{}, fmt.Errorf(
 			"multiple %q sources configured, use --source to specify one: %s",
 			canonicalType, strings.Join(matches, ", "),

--- a/internal/resolve/engine.go
+++ b/internal/resolve/engine.go
@@ -117,6 +117,13 @@ func (e *Engine) Resolve(
 	return allItems, nil
 }
 
+// ResolveURL resolves a single URL to a FullItem without requiring an existing
+// item set. Returns (nil, nil) if no resolver matches the URL.
+// This is the public entry point for the `fetch` verb.
+func (e *Engine) ResolveURL(ctx context.Context, rawURL string) (models.FullItem, error) {
+	return e.resolveOne(ctx, rawURL)
+}
+
 // resolveOne tries each resolver in order and returns the first match.
 func (e *Engine) resolveOne(ctx context.Context, rawURL string) (models.FullItem, error) {
 	for _, r := range e.resolvers {

--- a/internal/sources/jira/source.go
+++ b/internal/sources/jira/source.go
@@ -132,6 +132,13 @@ func (s *JiraSource) Fetch(since time.Time, limit int) ([]models.FullItem, error
 	return allItems, nil
 }
 
+// FetchOne implements interfaces.Fetcher. key is a Jira issue key such as
+// "PROJ-123". This makes JiraSource usable with the `pkm-sync fetch jira/KEY`
+// verb without going through the bulk Fetch pipeline.
+func (s *JiraSource) FetchOne(ctx context.Context, key string) (models.FullItem, error) {
+	return s.FetchIssue(ctx, key)
+}
+
 // FetchIssue retrieves a single Jira issue by key (e.g. "PROJ-123") and converts
 // it to a FullItem. Used by the cross-source reference resolver.
 func (s *JiraSource) FetchIssue(ctx context.Context, issueKey string) (models.FullItem, error) {

--- a/pkg/interfaces/fetcher.go
+++ b/pkg/interfaces/fetcher.go
@@ -1,0 +1,21 @@
+package interfaces
+
+import (
+	"context"
+
+	"pkm-sync/pkg/models"
+)
+
+// Fetcher retrieves a single item by its source-native identifier (e.g. an issue
+// key like "PROJ-123", a file ID, or a message ID). Sources implement this
+// interface alongside Source when they support single-item access.
+//
+// The command layer discovers this capability via a runtime type assertion:
+//
+//	if f, ok := src.(interfaces.Fetcher); ok { ... }
+type Fetcher interface {
+	// FetchOne retrieves a single item by its source-native key.
+	// The key format is source-specific: "PROJ-123" for Jira, a Drive file ID,
+	// a Gmail thread ID, etc.
+	FetchOne(ctx context.Context, key string) (models.FullItem, error)
+}

--- a/pkg/interfaces/searcher.go
+++ b/pkg/interfaces/searcher.go
@@ -1,0 +1,20 @@
+package interfaces
+
+import (
+	"context"
+
+	"pkm-sync/pkg/models"
+)
+
+// Searcher queries a source's local index (FTS or vector store) for items
+// matching a text query. This is implemented by local index wrappers, not by
+// live source API clients.
+//
+// The command layer discovers this capability via a runtime type assertion:
+//
+//	if s, ok := backend.(interfaces.Searcher); ok { ... }
+type Searcher interface {
+	// Search queries the local index for items matching query and returns up to
+	// limit results. Implementations should return results ordered by relevance.
+	Search(ctx context.Context, query string, limit int) ([]models.FullItem, error)
+}

--- a/pkg/routing/identifier.go
+++ b/pkg/routing/identifier.go
@@ -1,0 +1,91 @@
+// Package routing provides argument parsing utilities for verb-centric CLI commands.
+package routing
+
+import "strings"
+
+// ParsedIdentifier is the result of parsing a `fetch` or `search` argument.
+// The argument can be a bare URL, a source-qualified key ("jira/PROJ-123"), or
+// a bare key (requires --source to disambiguate).
+type ParsedIdentifier struct {
+	// Raw is the original unparsed argument.
+	Raw string
+
+	// IsURL is true when the argument is an HTTP(S) URL (or the key part of a
+	// source-prefixed argument is a URL).
+	IsURL bool
+
+	// URL holds the URL string when IsURL is true.
+	URL string
+
+	// SourceType is the source type parsed from the prefix (e.g. "drive",
+	// "gmail", "jira"). Empty when the argument is a bare URL or a bare key
+	// without a prefix.
+	SourceType string
+
+	// Key is the source-native identifier after the source-type prefix. For bare
+	// URLs this is empty; use URL instead. For bare keys this equals Raw.
+	Key string
+}
+
+// Parse parses a fetch/search argument into its components.
+//
+// Parsing rules (checked in order):
+//  1. If raw starts with "http://" or "https://" → bare URL, IsURL=true.
+//  2. If raw contains "/" → split on the first "/". Left side is SourceType,
+//     right side is Key. If Key looks like a URL ("http…"), IsURL=true and URL
+//     is set to the Key portion (the source-type prefix is retained as context).
+//  3. Otherwise → bare key, SourceType and URL are empty.
+func Parse(raw string) ParsedIdentifier {
+	id := ParsedIdentifier{Raw: raw}
+
+	// Rule 1: bare URL
+	if strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
+		id.IsURL = true
+		id.URL = raw
+
+		return id
+	}
+
+	// Rule 2: source-type/key prefix
+	if idx := strings.Index(raw, "/"); idx >= 0 {
+		id.SourceType = raw[:idx]
+		id.Key = raw[idx+1:]
+
+		// Key might itself be a URL (e.g. "drive/https://docs.google.com/...")
+		if strings.HasPrefix(id.Key, "http://") || strings.HasPrefix(id.Key, "https://") {
+			id.IsURL = true
+			id.URL = id.Key
+		}
+
+		return id
+	}
+
+	// Rule 3: bare key — leave SourceType and URL empty
+	id.Key = raw
+
+	return id
+}
+
+// sourceTypeAliases maps common short names to canonical source type strings
+// as used in config (e.g. "google_drive", "gmail", etc.).
+var sourceTypeAliases = map[string]string{
+	"drive":      "google_drive",
+	"calendar":   "google_calendar",
+	"cal":        "google_calendar",
+	"gmail":      "gmail",
+	"jira":       "jira",
+	"slack":      "slack",
+	"snow":       "servicenow",
+	"servicenow": "servicenow",
+}
+
+// CanonicalSourceType converts a short alias (e.g. "drive") to the canonical
+// config source type string (e.g. "google_drive"). Returns the input unchanged
+// if no alias is found.
+func CanonicalSourceType(alias string) string {
+	if canonical, ok := sourceTypeAliases[strings.ToLower(alias)]; ok {
+		return canonical
+	}
+
+	return alias
+}


### PR DESCRIPTION
- Introduces three primary verb commands (`fetch`, `search`, `sync`) replacing the source-centric structure where source type was the top-level command
- Source-centric commands (`gmail`, `drive`, `slack`, `jira`, `servicenow`) are deprecated in Cobra — hidden from help, still functional, emit a migration hint
- Adds two new opt-in interfaces (`Fetcher`, `Searcher`) and an identifier parsing package (`pkg/routing`)
**`fetch <url-or-identifier>`** — retrieve a single item:
```
pkm-sync fetch https://docs.google.com/document/d/abc/edit   # auto-routed via Resolver
pkm-sync fetch jira/PROJ-123                                  # type-prefixed key
pkm-sync fetch jira/PROJ-123 --source jira_work               # disambiguate multi-instance
pkm-sync fetch drive/FILE_ID --format md --output ./docs/
```
**`search [type[/source]] <query>`** — two-arg routing:
```
pkm-sync search "kubernetes deployment"          # vector search, all sources
pkm-sync search gmail "rosa boundary"            # Gmail FTS via archive.db
pkm-sync search gmail/work_gmail "rosa boundary" # FTS, specific source
pkm-sync search slack "deploy failed"            # vector search, slack filter
```
**`sync [source]`** — optional positional filter:
```
pkm-sync sync                  # all enabled sources (unchanged)
pkm-sync sync gmail            # all enabled Gmail sources
pkm-sync sync gmail_work       # specific source by name
```
- `pkg/routing/identifier.go` — `Parse()` handles bare URLs (auto-routed), `type/key` prefix, and bare keys
- `pkg/interfaces/fetcher.go` — `Fetcher.FetchOne(ctx, key)` opt-in interface; `JiraSource` implements it wrapping the existing `FetchIssue()`
- `resolve.Engine.ResolveURL()` — exposes the existing private `resolveOne` for use by the `fetch` verb
- `cmd/verb_helpers.go` — `findSourceByType()` shared source lookup
- [ ] `pkm-sync fetch https://docs.google.com/document/d/<id>/edit` outputs document content
- [ ] `pkm-sync fetch jira/PROJ-123` fetches a single Jira issue
- [ ] `pkm-sync search gmail "query"` hits archive.db FTS
- [ ] `pkm-sync search gmail/work_gmail "query"` filters to that source
- [ ] `pkm-sync search "query"` still does vector search (existing behavior)
- [ ] `pkm-sync sync gmail` syncs only Gmail sources
- [ ] `pkm-sync gmail` still works but prints deprecation warning
- [ ] `go test ./...` passes
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pkm-sync fetch` for single-item retrieval (URL or identifier) with format and file output options.
  * Search accepts optional type/source specifier and supports Gmail full-text archive search with text/JSON output.
  * Sync accepts an optional positional source name or type filter.

* **Improvements**
  * New routing and resolution enhancements for identifier parsing and URL resolving.
  * Single-item fetch capability exposed for additional sources.

* **Deprecated**
  * Legacy commands (`drive`, `drive-fetch`, `gmail`, `jira`, `servicenow`, `slack`) marked deprecated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->