### PR TITLE
sinks: Skip writing files when content is unchanged

### DIFF
--- a/internal/sinks/file.go
+++ b/internal/sinks/file.go
@@ -88,6 +88,14 @@ func (s *FileSink) writeItem(item models.FullItem) error {
 		return err
 	}
 
+	// Skip writing if file content is unchanged to avoid bumping mtime.
+	ondisk, err := os.ReadFile(filePath)
+	if err == nil && string(ondisk) == content {
+		slog.Debug("Skipping unchanged file", "path", filePath)
+
+		return nil
+	}
+
 	return os.WriteFile(filePath, []byte(content), 0644)
 }
 

--- a/internal/sinks/file_test.go
+++ b/internal/sinks/file_test.go
@@ -1,0 +1,101 @@
+package sinks
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"pkm-sync/pkg/models"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestFileSink(t *testing.T) (*FileSink, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	sink, err := NewFileSink("obsidian", dir, nil)
+	require.NoError(t, err)
+
+	return sink, dir
+}
+
+func makeTestItem(id, title, content string) models.FullItem {
+	return &models.BasicItem{
+		ID:         id,
+		Title:      title,
+		Content:    content,
+		SourceType: "jira",
+		ItemType:   "issue",
+		CreatedAt:  time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC),
+		Tags:       []string{"test"},
+		Metadata:   map[string]interface{}{"status": "Open"},
+	}
+}
+
+func TestWriteItem_SkipsUnchangedFile(t *testing.T) {
+	sink, dir := newTestFileSink(t)
+	item := makeTestItem("TEST-1", "Test Issue", "Some content")
+
+	// First write creates the file.
+	err := sink.Write(context.Background(), []models.FullItem{item})
+	require.NoError(t, err)
+
+	filePath := filepath.Join(dir, sink.fmt.formatFilename("Test Issue"))
+	info1, err := os.Stat(filePath)
+	require.NoError(t, err)
+
+	mtime1 := info1.ModTime()
+
+	// Ensure filesystem mtime granularity is exceeded.
+	time.Sleep(50 * time.Millisecond)
+
+	// Second write with identical content should not update mtime.
+	err = sink.Write(context.Background(), []models.FullItem{item})
+	require.NoError(t, err)
+
+	info2, err := os.Stat(filePath)
+	require.NoError(t, err)
+
+	assert.Equal(t, mtime1, info2.ModTime(), "mtime should not change for unchanged content")
+}
+
+func TestWriteItem_UpdatesChangedFile(t *testing.T) {
+	sink, dir := newTestFileSink(t)
+	item1 := makeTestItem("TEST-1", "Test Issue", "Original content")
+
+	err := sink.Write(context.Background(), []models.FullItem{item1})
+	require.NoError(t, err)
+
+	filePath := filepath.Join(dir, sink.fmt.formatFilename("Test Issue"))
+	original, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	// Write with different content should update.
+	item2 := makeTestItem("TEST-1", "Test Issue", "Updated content")
+	err = sink.Write(context.Background(), []models.FullItem{item2})
+	require.NoError(t, err)
+
+	updated, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, string(original), string(updated), "file content should change")
+	assert.Contains(t, string(updated), "Updated content")
+}
+
+func TestWriteItem_CreatesNewFile(t *testing.T) {
+	sink, dir := newTestFileSink(t)
+	item := makeTestItem("TEST-1", "New Issue", "Brand new")
+
+	err := sink.Write(context.Background(), []models.FullItem{item})
+	require.NoError(t, err)
+
+	filePath := filepath.Join(dir, sink.fmt.formatFilename("New Issue"))
+	content, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "Brand new")
+}


### PR DESCRIPTION
writeItem() unconditionally called os.WriteFile on every sync, bumping file mtimes even when content hadn't changed. This caused downstream tools (e.g. Obsidian dataview queries for "modified today") to show hundreds of false positives after each sync run.

Compare rendered content against the existing file before writing and skip the write when they match. The extra os.ReadFile per item is negligible — files are small markdown and most will be in the OS buffer cache from the ID index walk that already happens at startup.

Assisted-by: Claude Code (Claude Opus 4.6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized file writing to skip unnecessary rewrites when content is unchanged, preserving original file modification times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->